### PR TITLE
feat: add conda environment.yaml for linux

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -1,0 +1,27 @@
+name: everydream2
+channels:
+  - pytorch
+  - defaults
+dependencies:
+  - python=3.10.6
+  - pip
+  - cudatoolkit=11.3
+  - pip:
+      - --extra-index-url https://download.pytorch.org/whl/cu116
+      - torch==1.12.1+cu116
+      - torchvision==0.13.1+cu116
+      - transformers==4.25.1
+      - diffusers[torch]==0.10.2
+      - pynvml==11.4.1
+      - bitsandbytes==0.35.4
+      - ftfy==6.1.1
+      - aiohttp==3.8.3
+      - tensorboard>=2.11.0
+      - protobuf==3.20.1
+      - wandb==0.13.6
+      - pyre-extensions==0.0.23
+      - pytorch-lightning==1.6.5
+      - OmegaConf==2.2.3
+      - numpy==1.23.5 
+      - colorama==0.4.6
+


### PR DESCRIPTION
Adds an environment.yaml file for conda that works on Ubuntu linux. TODO: Add xformers. Using the one installed with `conda install xformers -c xformers/label/dev` did not work due to a missing CUDA C library.