### PR TITLE
Make file name extension check case insensitive, so .JPG or .PNG file will be detected

### DIFF
--- a/data/data_loader.py
+++ b/data/data_loader.py
@@ -231,7 +231,7 @@ class DataLoaderMultiAspect():
             current = os.path.join(recurse_root, f)
 
             if os.path.isfile(current):
-                ext = os.path.splitext(f)[1]
+                ext = os.path.splitext(f)[1].lower()
                 if ext in ['.jpg', '.jpeg', '.png', '.bmp', '.webp', '.jfif']:
                     # add image multiplyrepeats number of times
                     for _ in range(multiply):


### PR DESCRIPTION
The current check for file name extensions to find images within the data_root directory is case sensetive and images with .JPG or .PNG will be ignored.

I agree to the CLS as described under:
https://github.com/victorchall/EveryDream2trainer/blob/main/doc/EveryDream_CLA.txt
