### PR TITLE
Implemented system to train on a subset of the dataset, favoring higher rated images

### DIFF
--- a/data/data_loader.py
+++ b/data/data_loader.py
@@ -13,7 +13,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-
+import bisect
+import math
 import os
 import logging
 
@@ -46,7 +47,6 @@ class DataLoaderMultiAspect():
         self.log_folder = log_folder
         self.seed = seed
         self.batch_size = batch_size
-        self.runts = []
 
         self.aspects = aspects.get_aspect_buckets(resolution=resolution, square_only=False)
         logging.info(f"* DLMA resolution {resolution}, buckets: {self.aspects}")
@@ -56,16 +56,66 @@ class DataLoaderMultiAspect():
 
         self.__recurse_data_root(self=self, recurse_root=data_root)
         random.Random(seed).shuffle(self.image_paths)
-        self.prepared_train_data = self.__prescan_images(self.image_paths, flip_p) # ImageTrainItem[]
-        self.image_caption_pairs = self.__bucketize_images(self.prepared_train_data, batch_size=batch_size, debug_level=debug_level)
+        self.prepared_train_data = self.__prescan_images(self.image_paths, flip_p)
+        (self.rating_overall_sum, self.ratings_summed) = self.__sort_and_precalc_image_ratings()
 
-    def shuffle(self):
-        self.runts = []
-        self.seed = self.seed + 1
-        random.Random(self.seed).shuffle(self.prepared_train_data)
-        self.image_caption_pairs = self.__bucketize_images(self.prepared_train_data, batch_size=self.batch_size, debug_level=0)
+    def get_shuffled_image_buckets(self, dropout_fraction: float = 1.0):
+        """
+        returns the current list of images including their captions in a randomized order,
+        sorted into buckets with same sized images
+        if dropout_fraction < 1.0, only a subset of the images will be returned
+        :param dropout_fraction: must be between 0.0 and 1.0.
+        :return: randomized list of (image, caption) pairs, sorted into same sized buckets
+        """
+        """
+        Put images into buckets based on aspect ratio with batch_size*n images per bucket, discards remainder
+        """
+        # TODO: this is not terribly efficient but at least linear time
 
-    def unzip_all(self, path):
+        self.seed += 1
+        randomizer = random.Random(self.seed)
+
+        if dropout_fraction < 1.0:
+            picked_images = self.__pick_random_subset(dropout_fraction, randomizer)
+        else:
+            picked_images = self.prepared_train_data
+
+        randomizer.shuffle(picked_images)
+
+        buckets = {}
+        batch_size = self.batch_size
+        for image_caption_pair in picked_images:
+            image_caption_pair.runt_size = 0
+            target_wh = image_caption_pair.target_wh
+
+            if (target_wh[0],target_wh[1]) not in buckets:
+                buckets[(target_wh[0],target_wh[1])] = []
+            buckets[(target_wh[0],target_wh[1])].append(image_caption_pair)
+
+        if len(buckets) > 1:
+            for bucket in buckets:
+                truncate_count = len(buckets[bucket]) % batch_size
+                if truncate_count > 0:
+                    runt_bucket = buckets[bucket][-truncate_count:]
+                    for item in runt_bucket:
+                        item.runt_size = truncate_count
+                    while len(runt_bucket) < batch_size:
+                        runt_bucket.append(random.choice(runt_bucket))
+
+                    current_bucket_size = len(buckets[bucket])
+
+                    buckets[bucket] = buckets[bucket][:current_bucket_size - truncate_count]
+                    buckets[bucket].extend(runt_bucket)
+
+        # flatten the buckets
+        image_caption_pairs = []
+        for bucket in buckets:
+            image_caption_pairs.extend(buckets[bucket])
+
+        return image_caption_pairs
+
+    @staticmethod
+    def unzip_all(path):
         try:
             for root, dirs, files in os.walk(path):
                 for file in files:
@@ -76,8 +126,16 @@ class DataLoaderMultiAspect():
         except Exception as e:
             logging.error(f"Error unzipping files {e}")
 
-    def get_all_images(self):
-        return self.image_caption_pairs
+    def __sort_and_precalc_image_ratings(self) -> tuple[float, list[float]]:
+        self.prepared_train_data = sorted(self.prepared_train_data, key=lambda img: img.caption.rating())
+
+        rating_overall_sum: float = 0.0
+        ratings_summed: list[float] = []
+        for image in self.prepared_train_data:
+            rating_overall_sum += image.caption.rating()
+            ratings_summed.append(rating_overall_sum)
+
+        return rating_overall_sum, ratings_summed
 
     @staticmethod
     def __read_caption_from_file(file_path, fallback_caption: ImageCaption) -> ImageCaption:
@@ -97,6 +155,7 @@ class DataLoaderMultiAspect():
             try:
                 file_content = yaml.safe_load(stream)
                 main_prompt = file_content.get("main_prompt", "")
+                rating = file_content.get("rating", 1.0)
                 unparsed_tags = file_content.get("tags", [])
 
                 max_caption_length = file_content.get("max_caption_length", DEFAULT_MAX_CAPTION_LENGTH)
@@ -119,7 +178,7 @@ class DataLoaderMultiAspect():
 
                     last_weight = tag_weight
 
-                return ImageCaption(main_prompt, tags, tag_weights, max_caption_length, weights_differ)
+                return ImageCaption(main_prompt, rating, tags, tag_weights, max_caption_length, weights_differ)
 
             except:
                 logging.error(f" *** Error reading {file_path} to get caption, falling back to filename")
@@ -136,9 +195,9 @@ class DataLoaderMultiAspect():
         for tag in split_caption:
             tags.append(tag.strip())
 
-        return ImageCaption(main_prompt, tags, [1.0] * len(tags), DEFAULT_MAX_CAPTION_LENGTH, False)
+        return ImageCaption(main_prompt, 1.0, tags, [1.0] * len(tags), DEFAULT_MAX_CAPTION_LENGTH, False)
 
-    def __prescan_images(self, image_paths: list, flip_p=0.0):
+    def __prescan_images(self, image_paths: list, flip_p=0.0) -> list[ImageTrainItem]:
         """
         Create ImageTrainItem objects with metadata for hydration later
         """
@@ -177,42 +236,42 @@ class DataLoaderMultiAspect():
 
         return decorated_image_train_items
 
-    def __bucketize_images(self, prepared_train_data: list, batch_size=1, debug_level=0):
+    def __pick_random_subset(self, dropout_fraction: float, picker: random.Random) -> list[ImageTrainItem]:
         """
-        Put images into buckets based on aspect ratio with batch_size*n images per bucket, discards remainder
+        Picks a random subset of all images
+        - The size of the subset is limited by dropout_faction
+        - The chance of an image to be picked is influenced by its rating. Double that rating -> double the chance
+        :param dropout_fraction: must be between 0.0 and 1.0
+        :param picker: seeded random picker
+        :return: list of picked ImageTrainItem
         """
-        # TODO: this is not terribly efficient but at least linear time
-        buckets = {}
 
-        for image_caption_pair in prepared_train_data:
-            image_caption_pair.runt_size = 0
-            target_wh = image_caption_pair.target_wh
+        prepared_train_data = self.prepared_train_data.copy()
+        ratings_summed = self.ratings_summed.copy()
+        rating_overall_sum = self.rating_overall_sum
 
-            if (target_wh[0],target_wh[1]) not in buckets:
-                buckets[(target_wh[0],target_wh[1])] = []
-            buckets[(target_wh[0],target_wh[1])].append(image_caption_pair)
+        num_images = len(prepared_train_data)
+        num_images_to_pick = math.ceil(num_images * dropout_fraction)
+        num_images_to_pick = max(min(num_images_to_pick, num_images), 0)
 
-        if len(buckets) > 1:
-            for bucket in buckets:
-                truncate_count = len(buckets[bucket]) % batch_size
-                if truncate_count > 0:
-                    runt_bucket = buckets[bucket][-truncate_count:]
-                    for item in runt_bucket:
-                        item.runt_size = truncate_count
-                    while len(runt_bucket) < batch_size:
-                        runt_bucket.append(random.choice(runt_bucket))
+        # logging.info(f"Picking {num_images_to_pick} images out of the {num_images} in the dataset for drop_fraction {dropout_fraction}")
 
-                    current_bucket_size = len(buckets[bucket])
+        picked_images: list[ImageTrainItem] = []
+        while num_images_to_pick > len(picked_images):
+            # find random sample in dataset
+            point = picker.uniform(0.0, rating_overall_sum)
+            pos = min(bisect.bisect_left(ratings_summed, point), len(prepared_train_data) -1 )
 
-                    buckets[bucket] = buckets[bucket][:current_bucket_size - truncate_count]
-                    buckets[bucket].extend(runt_bucket)
+            # pick random sample
+            picked_image = prepared_train_data[pos]
+            picked_images.append(picked_image)
 
-        # flatten the buckets
-        image_caption_pairs = []
-        for bucket in buckets:
-            image_caption_pairs.extend(buckets[bucket])
+            # kick picked item out of data set to not pick it again
+            rating_overall_sum = max(rating_overall_sum - picked_image.caption.rating(), 0.0)
+            ratings_summed.pop(pos)
+            prepared_train_data.pop(pos)
 
-        return image_caption_pairs
+        return picked_images
 
     @staticmethod
     def __recurse_data_root(self, recurse_root):

--- a/data/image_train_item.py
+++ b/data/image_train_item.py
@@ -31,7 +31,7 @@ class ImageCaption:
     Represents the various parts of an image caption
     """
 
-    def __init__(self, main_prompt: str, tags: list[str], tag_weights: list[float], max_target_length: int, use_weights: bool):
+    def __init__(self, main_prompt: str, rating: float, tags: list[str], tag_weights: list[float], max_target_length: int, use_weights: bool):
         """
         :param main_prompt: The part of the caption which should always be included
         :param tags: list of tags to pick from to fill the caption
@@ -40,6 +40,7 @@ class ImageCaption:
         :param use_weights: if ture, weights are considered when shuffling tags
         """
         self.__main_prompt = main_prompt
+        self.__rating = rating
         self.__tags = tags
         self.__tag_weights = tag_weights
         self.__max_target_length = max_target_length
@@ -49,6 +50,9 @@ class ImageCaption:
 
         if use_weights and len(tag_weights) > len(tags):
             self.__tag_weights = tag_weights[:len(tags)]
+
+    def rating(self) -> float:
+        return self.__rating
 
     def get_shuffled_caption(self, seed: int) -> str:
         """
@@ -97,15 +101,15 @@ class ImageCaption:
         return ", ".join(tags)
 
 
-class ImageTrainItem():
+class ImageTrainItem:
     """
     image: PIL.Image
     identifier: caption,
     target_aspect: (width, height), 
     pathname: path to image file
     flip_p: probability of flipping image (0.0 to 1.0)
+    rating: the relative rating of the images. The rating is measured in comparison to the other images.
     """
-
     def __init__(self, image: PIL.Image, caption: ImageCaption, target_wh: list, pathname: str, flip_p=0.0):
         self.caption = caption
         self.target_wh = target_wh

--- a/train.json
+++ b/train.json
@@ -34,5 +34,7 @@
   "shuffle_tags": false,
   "useadam8bit": true,
   "wandb": false,
-  "write_schedule": false
+  "write_schedule": false,
+  "rated_dataset": false,
+  "rated_dataset_target_dropout_rate": 50
 }


### PR DESCRIPTION
First: I agree to the Contributor License Agreement

This is the second part of the dynamization of training data through a training session.
This PR focuses on skewing the selection of images to train to higher rated images.

This is done by leaving out less favorabel images in later epochs, at an increasing rate.
The result is that the model has seen more favorabel images more often and more recently at the end of the training session.

To accomplish this the user can define a rating per image in the YAML file.
The rating of one image is compared to the ratings of the other images. A rating twice as high then the rating of another image would result in twice as high a chance to be picked in the later stages of the training.

The second parameter is the target dropout rate in percent at the last epoch of the training. 
The default is 50%, meaning that 50 percent of the training images will be skipped at the last epoch.

The first epoch will always be trained on all images. The epochs between will drop out more and more images in a linear regression.

Each image has a chance to be picked for an epoch, but the chance of being picked relates to its rating.
