### PR TITLE
Bugfix: Adding same Tag twice to Caption

### DIFF
--- a/data/image_train_item.py
+++ b/data/image_train_item.py
@@ -105,10 +105,6 @@ class ImageCaption:
             if caption:
                 caption += ", "
             caption += tag
-            
-            if caption:
-                caption += ", "
-            caption += tag
 
         return caption
 


### PR DESCRIPTION
After the refactoring, the tag was added twice to the caption