### PR TITLE
a100 xformer link

### DIFF
--- a/Train_Colab.ipynb
+++ b/Train_Colab.ipynb
@@ -114,6 +114,7 @@
         "clear_output()\n",
         "!git clone https://github.com/victorchall/EveryDream2trainer.git\n",
         "%cd /content/EveryDream2trainer\n",
+        "!python utils/get_yamls.py\n",
         "clear_output()\n",
         "print(\"DONE!\")"
       ]
@@ -134,7 +135,6 @@
         "from IPython.display import clear_output\n",
         "!mkdir input\n",
         "%cd /content/EveryDream2trainer\n",
-        "!python utils/get_yamls.py\n",
         "MODEL_URL = \"https://huggingface.co/panopstor/EveryDream/resolve/main/sd_v1-5_vae.ckpt\" #@param [\"https://huggingface.co/panopstor/EveryDream/resolve/main/sd_v1-5_vae.ckpt\", \"https://huggingface.co/hakurei/waifu-diffusion-v1-3/resolve/main/wd-v1-3-float16.ckpt\"] {allow-input: true}\n",
         "print(\"Downloading \")\n",
         "!wget $MODEL_URL\n",

--- a/Train_Colab.ipynb
+++ b/Train_Colab.ipynb
@@ -102,7 +102,7 @@
         "!pip install -q wandb==0.13.6\n",
         "!pip install -q pyre-extensions==0.0.23\n",
         "if \"A100\" in s:\n",
-        "  !pip install -q https://huggingface.co/industriaditat/xformers_precompiles/blob/main/A100_13dev/xformers-0.0.13.dev0-py3-none-any.whl\n",
+        "  !pip install -q https://huggingface.co/industriaditat/xformers_precompiles/resolve/main/A100_13dev/xformers-0.0.13.dev0-py3-none-any.whl\n",
         "else:\n",
         "  !pip install -q https://huggingface.co/industriaditat/xformers_precompiles/resolve/main/T4_13dev/xformers-0.0.13.dev0-py3-none-any.whl\n",
         "!pip install -q pytorch-lightning==1.6.5\n",
@@ -110,10 +110,10 @@
         "!pip install -q numpy==1.23.5\n",
         "!pip install -q colorama\n",
         "!pip install -q keyboard\n",
+        "!pip install -q triton\n",
         "clear_output()\n",
         "!git clone https://github.com/victorchall/EveryDream2trainer.git\n",
         "%cd /content/EveryDream2trainer\n",
-        "!wget \"https://raw.githubusercontent.com/nawnie/EveryDream2trainer/main/train_colab.py\"\n",
         "clear_output()\n",
         "print(\"DONE!\")"
       ]


### PR DESCRIPTION
fixed link to a100 xformers

removed train_colab link to my github

added getyaml to dependencies cell previously this was tied to model download however if a user brings their own ckpt from somewhere else then they would not have the yamml for conversion

added pip install triton to dependencies cell
