### PR TITLE
Push DLMA into `main`, improvements to `data.resolve`

### DIFF
--- a/data/data_loader.py
+++ b/data/data_loader.py
@@ -27,10 +27,11 @@ class DataLoaderMultiAspect():
     """
     Data loader for multi-aspect-ratio training and bucketing
 
-    data_root: root folder of training data
+    image_train_items: list of `lImageTrainItem` objects
+    seed: random seed
     batch_size: number of images per batch
     """
-    def __init__(self, image_train_items, seed=555, batch_size=1):
+    def __init__(self, image_train_items: list[ImageTrainItem], seed=555, batch_size=1):
         self.seed = seed
         self.batch_size = batch_size
         # Prepare data

--- a/data/every_dream.py
+++ b/data/every_dream.py
@@ -25,14 +25,11 @@ import torch.nn.functional as F
 
 class EveryDreamBatch(Dataset):
     """
-    data_root: root path of all your training images, will be recursively searched for images
-    repeats: how many times to repeat each image in the dataset
-    flip_p: probability of flipping the image horizontally
+    data_loader: `DataLoaderMultiAspect` object
     debug_level: 0=none, 1=print drops due to unfilled batches on aspect ratio buckets, 2=debug info per image, 3=save crops to disk for inspection
-    batch_size: how many images to return in a batch
     conditional_dropout: probability of dropping the caption for a given image
-    resolution: max resolution (relative to square)
-    jitter: number of pixels to jitter the crop by, only for non-square images
+    crop_jitter: number of pixels to jitter the crop by, only for non-square images
+    seed: random seed
     """
     def __init__(self,
                  data_loader: DataLoaderMultiAspect,

--- a/data/every_dream.py
+++ b/data/every_dream.py
@@ -38,9 +38,7 @@ class EveryDreamBatch(Dataset):
                  crop_jitter=20,
                  seed=555,
                  tokenizer=None,
-                 log_folder=None,
                  retain_contrast=False,
-                 write_schedule=False,
                  shuffle_tags=False,
                  rated_dataset=False,
                  rated_dataset_dropout_target=0.5
@@ -52,10 +50,8 @@ class EveryDreamBatch(Dataset):
         self.crop_jitter = crop_jitter
         self.unloaded_to_idx = 0
         self.tokenizer = tokenizer
-        self.log_folder = log_folder
         self.max_token_length = self.tokenizer.model_max_length
         self.retain_contrast = retain_contrast
-        self.write_schedule = write_schedule
         self.shuffle_tags = shuffle_tags
         self.seed = seed
         self.rated_dataset = rated_dataset
@@ -64,18 +60,7 @@ class EveryDreamBatch(Dataset):
         self.image_train_items = self.data_loader.get_shuffled_image_buckets(1.0)
             
         num_images = len(self.image_train_items)
-
         logging.info(f" ** Trainer Set: {num_images / self.batch_size:.0f}, num_images: {num_images}, batch_size: {self.batch_size}")
-        if self.write_schedule:
-            self.__write_batch_schedule(0)
-
-    def __write_batch_schedule(self, epoch_n):
-        with open(f"{self.log_folder}/ep{epoch_n}_batch_schedule.txt", "w", encoding='utf-8') as f:
-            for i in range(len(self.image_train_items)):
-                try:
-                    f.write(f"step:{int(i / self.batch_size):05}, wh:{self.image_train_items[i].target_wh}, r:{self.image_train_items[i].runt_size}, path:{self.image_train_items[i].pathname}\n")
-                except Exception as e:
-                    logging.error(f" * Error writing to batch schedule for file path: {self.image_train_items[i].pathname}")
 
     def shuffle(self, epoch_n: int, max_epochs: int):
         self.seed += 1
@@ -86,9 +71,6 @@ class EveryDreamBatch(Dataset):
             dropout_fraction = 1.0
 
         self.image_train_items = self.data_loader.get_shuffled_image_buckets(dropout_fraction)
-
-        if self.write_schedule:
-            self.__write_batch_schedule(epoch_n + 1)
 
     def __len__(self):
         return len(self.image_train_items)

--- a/data/resolver.py
+++ b/data/resolver.py
@@ -4,18 +4,21 @@ import os
 import random
 import typing
 import zipfile
+import argparse
 
-import PIL.Image as Image
 import tqdm
 from colorama import Fore, Style
 
 from data.image_train_item import ImageCaption, ImageTrainItem
 
 class DataResolver:
-    def __init__(self, aspects: list[typing.Tuple[int, int]], flip_p=0.0, seed=555):
-        self.seed = seed
-        self.aspects = aspects
-        self.flip_p = flip_p
+    def __init__(self, args: argparse.Namespace):
+        """
+        :param args: EveryDream configuration, an `argparse.Namespace` object.
+        """
+        self.aspects = args.aspects
+        self.flip_p = args.flip_p
+        self.seed = args.seed
         
     def image_train_items(self, data_root: str) -> list[ImageTrainItem]:
         """
@@ -173,8 +176,11 @@ class DirectoryResolver(DataResolver):
             if os.path.isdir(current):
                 yield from DirectoryResolver.recurse_data_root(current)
         
-
-def strategy(data_root: str):
+def strategy(data_root: str) -> typing.Type[DataResolver]:
+    """
+    Determine the strategy to use for resolving the data.
+    :param data_root: The root directory or JSON file to resolve.
+    """
     if os.path.isfile(data_root) and data_root.endswith('.json'):
         return JSONResolver
     
@@ -183,41 +189,37 @@ def strategy(data_root: str):
         
     raise ValueError(f"data_root '{data_root}' is not a valid directory or JSON file.")
                     
-
-def resolve_root(path: str, aspects: list[float], flip_p: float = 0.0, seed=555) -> list[ImageTrainItem]:
+def resolve_root(path: str, args: argparse.Namespace) -> list[ImageTrainItem]:
     """
-    :param data_root: Directory or JSON file.
-    :param aspects: The list of aspect ratios to use
-    :param flip_p: The probability of flipping the image
+    Resolve the training data from the root path.
+    :param path: The root path to resolve.
+    :param args: EveryDream configuration, an `argparse.Namespace` object.
     """
-    if os.path.isfile(path) and path.endswith('.json'):
-        return JSONResolver(aspects, flip_p, seed).image_train_items(path)
-    
-    if os.path.isdir(path):
-        return DirectoryResolver(aspects, flip_p, seed).image_train_items(path)
-        
-    raise ValueError(f"data_root '{path}' is not a valid directory or JSON file.")
+    resolver = strategy(path)
+    return resolver(args).image_train_items(path)
 
-def resolve(value: typing.Union[dict, str], aspects: list[float], flip_p: float=0.0, seed=555) -> list[ImageTrainItem]:
+def resolve(value: typing.Union[dict, str], args: argparse.Namespace) -> list[ImageTrainItem]:
     """
     Resolve the training data from the value.
-    :param value: The value to resolve, either a dict or a string.
-    :param aspects: The list of aspect ratios to use
-    :param flip_p: The probability of flipping the image
+    :param value: The value to resolve, either a dict, an array, or a string.
+    :param args: EveryDream configuration, an `argparse.Namespace` object.
     """
     if isinstance(value, str):
-        return resolve_root(value, aspects, flip_p)
+        return resolve_root(value, args)
     
     if isinstance(value, dict):
         resolver = value.get('resolver', None)
         match resolver:
             case 'directory' | 'json':
                 path = value.get('path', None)
-                return resolve_root(path, aspects, flip_p, seed)
+                return resolve_root(path, args)
             case 'multi':
-                items = []
-                for resolver in value.get('resolvers', []):
-                    items += resolve(resolver, aspects, flip_p, seed)
-                return items
+                return resolve(value.get('resolvers', []), args)
             case _:
                 raise ValueError(f"Cannot resolve training data for resolver value '{resolver}'")
+
+    if isinstance(value, list):
+        items = []
+        for item in value:
+            items += resolve(item, args)
+        return items 

--- a/test/test_data_resolver.py
+++ b/test/test_data_resolver.py
@@ -117,3 +117,21 @@ class TestResolve(unittest.TestCase):
         
         undersized_images = list(filter(lambda i: i.is_undersized, items))
         self.assertEqual(len(undersized_images), 1)
+        
+    def test_resolve_with_list(self):
+        data_root_spec = [
+            DATA_PATH,
+            JSON_ROOT_PATH,
+        ]
+        
+        items = resolver.resolve(data_root_spec, ARGS)
+        image_paths = [item.pathname for item in items]
+        image_captions = [item.caption for item in items]
+        captions = [caption.get_caption() for caption in image_captions]
+        
+        self.assertEqual(len(items), 6)
+        self.assertEqual(image_paths, [IMAGE_1_PATH, IMAGE_2_PATH, IMAGE_3_PATH] * 2)
+        self.assertEqual(captions, ['caption for test1', 'test2', 'test3', 'caption for test1', 'caption for test2', 'test3'])
+        
+        undersized_images = list(filter(lambda i: i.is_undersized, items))
+        self.assertEqual(len(undersized_images), 2)

--- a/test/test_data_resolver.py
+++ b/test/test_data_resolver.py
@@ -2,6 +2,7 @@ import json
 import glob
 import os
 import unittest
+import argparse
 
 import PIL.Image as Image
 
@@ -10,12 +11,17 @@ import data.resolver as resolver
 
 DATA_PATH = os.path.abspath('./test/data')
 JSON_ROOT_PATH = os.path.join(DATA_PATH, 'test_root.json')
-ASPECTS = aspects.get_aspect_buckets(512)
 
 IMAGE_1_PATH = os.path.join(DATA_PATH, 'test1.jpg')
 CAPTION_1_PATH = os.path.join(DATA_PATH, 'test1.txt')
 IMAGE_2_PATH = os.path.join(DATA_PATH, 'test2.jpg')
 IMAGE_3_PATH = os.path.join(DATA_PATH, 'test3.jpg')
+
+ARGS = argparse.Namespace(
+    aspects=aspects.get_aspect_buckets(512),
+    flip_p=0.5,
+    seed=42,
+)
 
 class TestResolve(unittest.TestCase):
     @classmethod
@@ -51,7 +57,7 @@ class TestResolve(unittest.TestCase):
             os.remove(file)    
 
     def test_directory_resolve_with_str(self):
-        items = resolver.resolve(DATA_PATH, ASPECTS)
+        items = resolver.resolve(DATA_PATH, ARGS)
         image_paths = [item.pathname for item in items]
         image_captions = [item.caption for item in items]
         captions = [caption.get_caption() for caption in image_captions]
@@ -69,7 +75,7 @@ class TestResolve(unittest.TestCase):
             'path': DATA_PATH,
         }
         
-        items = resolver.resolve(data_root_spec, ASPECTS)
+        items = resolver.resolve(data_root_spec, ARGS)
         image_paths = [item.pathname for item in items]
         image_captions = [item.caption for item in items]
         captions = [caption.get_caption() for caption in image_captions]
@@ -82,7 +88,7 @@ class TestResolve(unittest.TestCase):
         self.assertEqual(len(undersized_images), 1)
     
     def test_json_resolve_with_str(self):
-        items = resolver.resolve(JSON_ROOT_PATH, ASPECTS)
+        items = resolver.resolve(JSON_ROOT_PATH, ARGS)
         image_paths = [item.pathname for item in items]
         image_captions = [item.caption for item in items]
         captions = [caption.get_caption() for caption in image_captions]
@@ -100,7 +106,7 @@ class TestResolve(unittest.TestCase):
             'path': JSON_ROOT_PATH,
         }
         
-        items = resolver.resolve(data_root_spec, ASPECTS)
+        items = resolver.resolve(data_root_spec, ARGS)
         image_paths = [item.pathname for item in items]
         image_captions = [item.caption for item in items]
         captions = [caption.get_caption() for caption in image_captions]

--- a/train.py
+++ b/train.py
@@ -329,7 +329,7 @@ def resolve_image_train_items(args: argparse.Namespace, log_folder: str) -> list
     
     return image_train_items
                 
-def write_batch_schedule(log_folder, train_batch, epoch):
+def write_batch_schedule(args: argparse.Namespace, log_folder: str, train_batch: EveryDreamBatch, epoch: int):
     if args.write_schedule:
         with open(f"{log_folder}/ep{epoch}_batch_schedule.txt", "w", encoding='utf-8') as f:
             for i in range(len(train_batch.image_train_items)):
@@ -783,7 +783,7 @@ def main(args):
         # # discard the grads, just want to pin memory
         # optimizer.zero_grad(set_to_none=True)
 
-        write_batch_schedule(log_folder, train_batch, 0)
+        write_batch_schedule(args, log_folder, train_batch, 0)
         
         for epoch in range(args.max_epochs):
             loss_epoch = []
@@ -935,7 +935,7 @@ def main(args):
             epoch_pbar.update(1)
             if epoch < args.max_epochs - 1:
                 train_batch.shuffle(epoch_n=epoch, max_epochs = args.max_epochs)
-                write_batch_schedule(log_folder, train_batch, epoch + 1)
+                write_batch_schedule(args, log_folder, train_batch, epoch + 1)
 
             loss_local = sum(loss_epoch) / len(loss_epoch)
             log_writer.add_scalar(tag="loss/epoch", scalar_value=loss_local, global_step=global_step)


### PR DESCRIPTION
This patch

* passes the configuration (`argparse.Namespace`) to the resolver,
* pushes the DLMA code into the main function,
* makes DLMA take a `list[ImageTrainItem]` instead of `data_root`,
* makes `EveryDreamBatch` take a DLMA instance instead of `data_root`,
* moves `write_batch_schedule` to `train.py`,
* allows `data_root` to be a list for conveniently specifying a many directories and/or JSON files.

By doing these things, both `EveryDreamBatch` and DLMA can be free from data resolution logic, reporting errors, and logging undersized image information. The arguments passed down to EDB and DLMA are the essential ones they need. This should also mean that there is no need for the data loader singleton. If I am wrong about that, I can put the `dls` initialization back in.