### PR TITLE
Xformer update

### DIFF
--- a/Train_Colab.ipynb
+++ b/Train_Colab.ipynb
@@ -101,7 +101,7 @@
         "!pip install -q protobuf==3.20.1\n",
         "!pip install -q wandb==0.13.6\n",
         "!pip install -q pyre-extensions==0.0.23\n",
-        "!pip install -q xformers==0.0.17.dev435\n",
+        "!pip install -q xformers==0.0.16\n",
         "!pip install -q pytorch-lightning==1.6.5\n",
         "!pip install -q OmegaConf==2.2.3\n",
         "!pip install -q numpy==1.23.5\n",


### PR DESCRIPTION
Prior version of Xformers is no longer available switching link to last stable release.

https://pypi.org/project/xformers/#history

Tested!