### PR TITLE
Fix multiplier issues with validation, and refactor validation logic

### DIFF
--- a/data/every_dream.py
+++ b/data/every_dream.py
@@ -65,12 +65,6 @@ class EveryDreamBatch(Dataset):
         num_images = len(self.image_train_items)
         logging.info(f" ** Dataset '{name}': {num_images / self.batch_size:.0f} batches, num_images: {num_images}, batch_size: {self.batch_size}")
 
-    def get_random_split(self, split_proportion: float, remove_from_dataset: bool=False) -> list[ImageTrainItem]:
-        items = self.data_loader.get_random_split(split_proportion, remove_from_dataset)
-        self.__update_image_train_items(1.0)
-        return items
-
-
     def shuffle(self, epoch_n: int, max_epochs: int):
         self.seed += 1
         

--- a/data/image_train_item.py
+++ b/data/image_train_item.py
@@ -263,7 +263,7 @@ class ImageTrainItem:
         self.multiplier = multiplier
 
         self.image_size = None
-        if image is None:
+        if image is None or len(image) == 0:
             self.image = []
         else:
             self.image = image

--- a/data/resolver.py
+++ b/data/resolver.py
@@ -128,7 +128,7 @@ class DirectoryResolver(DataResolver):
                         with open(multiply_txt_path, 'r') as f:
                             val = float(f.read().strip())
                             multipliers[current_dir] = val
-                            logging.info(f" * DLMA multiply.txt in {current_dir} set to {val}")
+                            logging.info(f" - multiply.txt in '{current_dir}' set to {val}")
                     except Exception as e:
                         logging.warning(f" * {Fore.LIGHTYELLOW_EX}Error trying to read multiply.txt for {current_dir}: {Style.RESET_ALL}{e}")
                         multipliers[current_dir] = 1.0
@@ -137,16 +137,8 @@ class DirectoryResolver(DataResolver):
             
             caption = ImageCaption.resolve(pathname)
             item = self.image_train_item(pathname, caption, multiplier=multipliers[current_dir])
-            
-            cur_file_multiplier = multipliers[current_dir]
+            items.append(item)
 
-            while cur_file_multiplier >= 1.0:
-                items.append(item)
-                cur_file_multiplier -= 1
-            
-            if cur_file_multiplier > 0:
-                if randomizer.random() < cur_file_multiplier:
-                    items.append(item) 
         return items
         
     @staticmethod

--- a/train.py
+++ b/train.py
@@ -550,6 +550,7 @@ def main(args):
     except Exception as e:
         traceback.print_exc()
         logging.error(" * Failed to load checkpoint *")
+        raise
 
     if args.gradient_checkpointing:
         unet.enable_gradient_checkpointing()

--- a/train.py
+++ b/train.py
@@ -160,20 +160,21 @@ def append_epoch_log(global_step: int, epoch_pbar, gpu, log_writer, **logs):
     """
     updates the vram usage for the epoch
     """
-    gpu_used_mem, gpu_total_mem = gpu.get_gpu_memory()
-    log_writer.add_scalar("performance/vram", gpu_used_mem, global_step)
-    epoch_mem_color = Style.RESET_ALL
-    if gpu_used_mem > 0.93 * gpu_total_mem:
-        epoch_mem_color = Fore.LIGHTRED_EX
-    elif gpu_used_mem > 0.85 * gpu_total_mem:
-        epoch_mem_color = Fore.LIGHTYELLOW_EX
-    elif gpu_used_mem > 0.7 * gpu_total_mem:
-        epoch_mem_color = Fore.LIGHTGREEN_EX
-    elif gpu_used_mem < 0.5 * gpu_total_mem:
-        epoch_mem_color = Fore.LIGHTBLUE_EX
+    if gpu is not None:
+        gpu_used_mem, gpu_total_mem = gpu.get_gpu_memory()
+        log_writer.add_scalar("performance/vram", gpu_used_mem, global_step)
+        epoch_mem_color = Style.RESET_ALL
+        if gpu_used_mem > 0.93 * gpu_total_mem:
+            epoch_mem_color = Fore.LIGHTRED_EX
+        elif gpu_used_mem > 0.85 * gpu_total_mem:
+            epoch_mem_color = Fore.LIGHTYELLOW_EX
+        elif gpu_used_mem > 0.7 * gpu_total_mem:
+            epoch_mem_color = Fore.LIGHTGREEN_EX
+        elif gpu_used_mem < 0.5 * gpu_total_mem:
+            epoch_mem_color = Fore.LIGHTBLUE_EX
 
-    if logs is not None:
-        epoch_pbar.set_postfix(**logs, vram=f"{epoch_mem_color}{gpu_used_mem}/{gpu_total_mem} MB{Style.RESET_ALL} gs:{global_step}")
+        if logs is not None:
+            epoch_pbar.set_postfix(**logs, vram=f"{epoch_mem_color}{gpu_used_mem}/{gpu_total_mem} MB{Style.RESET_ALL} gs:{global_step}")
 
 
 def set_args_12gb(args):
@@ -372,6 +373,7 @@ def main(args):
     else:
         logging.warning("*** Running on CPU. This is for testing loading/config parsing code only.")
         device = 'cpu'
+        gpu = None
 
     log_folder = os.path.join(args.logdir, f"{args.project_name}_{log_time}")
 
@@ -714,8 +716,9 @@ def main(args):
     if not os.path.exists(f"{log_folder}/samples/"):
         os.makedirs(f"{log_folder}/samples/")
 
-    gpu_used_mem, gpu_total_mem = gpu.get_gpu_memory()
-    logging.info(f" Pretraining GPU Memory: {gpu_used_mem} / {gpu_total_mem} MB")
+    if gpu is not None:
+        gpu_used_mem, gpu_total_mem = gpu.get_gpu_memory()
+        logging.info(f" Pretraining GPU Memory: {gpu_used_mem} / {gpu_total_mem} MB")
     logging.info(f" saving ckpts every {args.ckpt_every_n_minutes} minutes")
     logging.info(f" saving ckpts every {args.save_every_n_epochs } epochs")
 


### PR DESCRIPTION
There's some changes in here to how multiplier.txt is applied. 

Mainly, the logic has been simplified and moved to runtime rather than load time. On `DataLoaderMultiAspect` multipliers are lazily applied in `__pick_multiplied_set()`, rather than being pre-baked into `prepared_train_data`. The main implication of this is that for fractional multipliers, EveryDream will now train with a different random subset of the folder each epoch, rather than picking the subset once on load and then re-using the same subset every epoch.

I have not extensively tested this - please check that it works as expected with fractional and also >1 multipliers before merging.