### PR TITLE
ignore multiply.txt option

### DIFF
--- a/train.py
+++ b/train.py
@@ -1029,6 +1029,7 @@ if __name__ == "__main__":
     argparser.add_argument("--write_schedule", action="store_true", default=False, help="write schedule of images and their batches to file (def: False)")
     argparser.add_argument("--rated_dataset", action="store_true", default=False, help="enable rated image set training, to less often train on lower rated images through the epochs")
     argparser.add_argument("--rated_dataset_target_dropout_percent", type=int, default=50, help="how many images (in percent) should be included in the last epoch (Default 50)")
+    argparser.add_argument("--ignore-multiply", action="store_true", default=False, help="Ignore the multiply.txt file.")
 
     # load CLI args to overwrite existing config args
     args = argparser.parse_args(args=argv, namespace=args)


### PR DESCRIPTION
Might be useful for doing a quick pass over your dataset with text encoder or unet encoder disabled...

```
 Preloading images...
  0%|         | 0/10 [00:00<?, ?it/s]
Ignoring 'multiply.txt' file found in 'C:\sd\training\datasets\testdir01' directory due to --ignore-multiply flag.
Ignoring 'multiply.txt' file found in 'C:\sd\training\datasets\testdir02' directory due to --ignore-multiply flag.
100%|██████████████████████████████████████████████████████████████████████████████| 10/10 [00:00<00:00, 2415.21it/s]
 * Found 10 files in ...
```