### PR TITLE
option to load data set from zip file {way faster}

### DIFF
--- a/Train_Colab.ipynb
+++ b/Train_Colab.ipynb
@@ -27,8 +27,8 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "cellView": "form",
-        "id": "WsYIcz9HY9lx"
+        "id": "WsYIcz9HY9lx",
+        "cellView": "form"
       },
       "outputs": [],
       "source": [
@@ -37,6 +37,8 @@
         "import os\n",
         "import time\n",
         "from IPython.display import clear_output\n",
+        "!pip install -q colorama   # preinstall to be able to load diffusers into notebook *colab is weird\n",
+        "!pip install -q diffusers[torch]==0.13.0\n",
         "!wget https://github.com/korakot/kora/releases/download/v0.10/py310.sh\n",
         "!bash ./py310.sh -b -f -p /usr/local\n",
         "!python -m ipykernel install --name \"py310\" --user\n",
@@ -222,12 +224,13 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "cellView": "form",
-        "id": "bLpcvpGJB4Gu"
+        "id": "bLpcvpGJB4Gu",
+        "cellView": "form"
       },
       "outputs": [],
       "source": [
         "#@title Pick your base model from a diffusers model saved to your Gdrive (converted above)\n",
+        "from subprocess import getoutput\n",
         "\n",
         "#@markdown Do not skip this cell.\n",
         "\n",
@@ -237,7 +240,8 @@
         "\n",
         "#@markdown The default for SD1.5 converted above would be */content/drive/MyDrive/everydreamlogs/ckpt/SD15*\n",
         "Resume_Model = \"/content/drive/MyDrive/everydreamlogs/ckpt/SD15\" #@param{type:\"string\"} \n",
-        "save_name = Resume_Model"
+        "save_name = Resume_Model\n",
+        "s = getoutput('nvidia-smi') ## reload info after reseting instance from samples cell"
       ]
     },
     {
@@ -262,11 +266,14 @@
       "outputs": [],
       "source": [
         "#@title \n",
+        "%cd /content/EveryDream2trainer\n",
         "#@markdown # Run Everydream 2\n",
         "#@markdown If you want to use a .json config or upload your own, skip this cell and run the cell below instead\n",
         "\n",
         "#@markdown * Save logs and output ckpts to Gdrive (strongly suggested)\n",
         "Save_to_Gdrive = True #@param{type:\"boolean\"}\n",
+        "#@markdown * when loading data sets over 200 images it is faster to load from a zip file\n",
+        "Load_from_Zip = False #@param{type:\"boolean\"}\n",
         "#@markdown * Use resume to contnue training you just ran, will also find latest diffusers log in your Gdrive to continue.\n",
         "resume = False #@param{type:\"boolean\"}\n",
         "#@markdown * Name your project so you can find it in your logs\n",
@@ -301,12 +308,12 @@
         "\n",
         "#@markdown * Location on your Gdrive where your training images are.\n",
         "Dataset_Location = \"/content/drive/MyDrive/training_samples\" #@param {type:\"string\"}\n",
-        "dataset = Dataset_Location\n",
+        "\n",
         "model = save_name\n",
         "\n",
         "#@markdown * Max Epochs to train for, this defines how many total times all your training data is used. Default of 100 is a good start if you are training ~30-40 images of one subject. If you have 100 images, you can reduce this to 40-50 and so forth.\n",
         "\n",
-        "Max_Epochs = 100 #@param {type:\"slider\", min:0, max:200, step:5}\n",
+        "Max_Epochs = 200 #@param {type:\"slider\", min:0, max:200, step:5}\n",
         "\n",
         "#@markdown * How often to save checkpoints.\n",
         "Save_every_N_epoch = 20 #@param{type:\"integer\"}\n",
@@ -355,13 +362,17 @@
         "# #@markdown Paste your token here if you have an account so you can use it to track your training progress.  If you don't have an account, you can create one for free at https://wandb.ai/site.  Log will use your project name from above. This is a free online logging utility.\n",
         "# #@markdown Your key is on this page: https://wandb.ai/settings under \"Danger Zone\" \"API Keys\"\n",
         "wandb_token = '' #@param{type:\"string\"}\n",
-        "\n",
-        "\n",
-        "\n",
         "wandb_settings = \"\"\n",
         "if wandb_token:\n",
         "  !wandb login $wandb_token\n",
         "  wandb_settings = \"--wandb\"\n",
+        "\n",
+        "if Load_from_Zip:\n",
+        "  !rm -r /Training_Data/\n",
+        "  !mkdir Training_Data\n",
+        "  !unzip $Dataset_Location -d /Training_Data\n",
+        "  Dataset_Location = \"/Training_Data\"\n",
+        "dataset = Dataset_Location\n",
         "\n",
         "Drive=\"\"\n",
         "if Save_to_Gdrive:\n",


### PR DESCRIPTION
no 

Zip

Preloading images...
100% 801/801 [02:50<00:00,  4.69it/s]



unzip time 6 seconds
Preloading images...
 74% 715/970 [00:01<00:00, 582.85it/s] - multiply.txt in '/Training_Data/Futurama_beta_v10/hermes' set to 1.25
 87% 848/970 [00:01<00:00, 623.31it/s] - multiply.txt in '/Training_Data/Futurama_beta_v10/amy' set to 0.4
100% 970/970 [00:01<00:00, 587.23it/s]

few minor changes prepping for redoing sample cell towards bottoms (installs diffusers before updating python) 
ill probably get to adding the inference cell using sample generator utility tonight


TL:DR loading 970 images takes 7 seconds as opposed to 801 images taking almost 3 mins 