### PR TITLE
Separate text encoder LR; logging & pbar improvements; misc sample generator tweaks

### DIFF
--- a/data/every_dream_validation.py
+++ b/data/every_dream_validation.py
@@ -105,7 +105,7 @@ class EveryDreamValidator:
         [Any, Any], tuple[torch.Tensor, torch.Tensor]]):
         with torch.no_grad(), isolate_rng():
             loss_validation_epoch = []
-            steps_pbar = tqdm(range(len(dataloader)), position=1)
+            steps_pbar = tqdm(range(len(dataloader)), position=1, leave=False)
             steps_pbar.set_description(f"{Fore.LIGHTCYAN_EX}Validate ({tag}){Style.RESET_ALL}")
 
             for step, batch in enumerate(dataloader):

--- a/data/resolver.py
+++ b/data/resolver.py
@@ -1,7 +1,6 @@
 import json
 import logging
 import os
-import random
 import typing
 import zipfile
 import argparse
@@ -18,8 +17,7 @@ class DataResolver:
         """
         self.aspects = args.aspects
         self.flip_p = args.flip_p
-        self.seed = args.seed
-        
+
     def image_train_items(self, data_root: str) -> list[ImageTrainItem]:
         """
         Get the list of `ImageTrainItem` for the given data root.
@@ -116,8 +114,7 @@ class DirectoryResolver(DataResolver):
         image_paths = list(DirectoryResolver.recurse_data_root(data_root))
         items = []
         multipliers = {}
-        randomizer = random.Random(self.seed)
-        
+
         for pathname in tqdm.tqdm(image_paths):
             current_dir = os.path.dirname(pathname)
             

--- a/doc/LOGGING.md
+++ b/doc/LOGGING.md
@@ -28,6 +28,8 @@ In place of `sample_prompts.txt` you can provide a `sample_prompts.json` file, w
   "scheduler": "dpm++",
   "num_inference_steps": 15,
   "show_progress_bars": true,
+  "generate_samples_every_n_steps": 200,
+  "generate_pretrain_samples": true,
   "samples": [
     {
       "prompt": "ted bennet and a man sitting on a sofa with a kitchen in the background",
@@ -46,7 +48,9 @@ In place of `sample_prompts.txt` you can provide a `sample_prompts.json` file, w
 }
 ```
 
-At the top you can set a `batch_size` (subject to VRAM limits), a default `seed` and `cfgs` to generate with, as well as a `scheduler` and `num_inference_steps` to control the quality of the samples. Available schedulers are `ddim` (the default) and `dpm++`. Finally, you can set `show_progress_bars` to `true` if you want to see progress bars during the sample generation process. 
+At the top you can set a `batch_size` (subject to VRAM limits), a default `seed` and `cfgs` to generate with, as well as a `scheduler` and `num_inference_steps` to control the quality of the samples. Available schedulers are `ddim` (the default) and `dpm++`. If you want to see sample progress bars you can set `show_progress_bars` to `true`. To generate a batch of samples before training begins, set `generate_pretrain_samples` to true. 
+
+Finally, you can override the `sample_steps` set in the main configuration .json file (or CLI) by setting `generate_samples_every_n_steps`. This value is read every time samples are updated, so if you initially pass `--sample_steps 200` and then later on you edit your `sample_prompts.json` file to add `"generate_samples_every_n_steps": 100`, after the next set of samples is generated you will start seeing new sets of image samples every 100 steps instead of only every 200 steps.
 
 Individual samples are defined under the `samples` key. Each sample can have a `prompt`, a `negative_prompt`, a `seed` (use `-1` to pick a different random seed each time), and a `size` (must be multiples of 64) or `aspect_ratio` (eg 1.77778 for 16:9). Use `"random_caption": true` to pick a random caption from the training set each time.
 

--- a/doc/LOGGING.md
+++ b/doc/LOGGING.md
@@ -35,7 +35,8 @@ In place of `sample_prompts.txt` you can provide a `sample_prompts.json` file, w
     },
     {
       "prompt": "a photograph of ted bennet riding a bicycle",
-      "seed": -1
+      "seed": -1,
+      "aspect_ratio": 1.77778
     },
     {
       "random_caption": true,
@@ -47,7 +48,7 @@ In place of `sample_prompts.txt` you can provide a `sample_prompts.json` file, w
 
 At the top you can set a `batch_size` (subject to VRAM limits), a default `seed` and `cfgs` to generate with, as well as a `scheduler` and `num_inference_steps` to control the quality of the samples. Available schedulers are `ddim` (the default) and `dpm++`. Finally, you can set `show_progress_bars` to `true` if you want to see progress bars during the sample generation process. 
 
-Individual samples are defined under the `samples` key. Each sample can have a `prompt`, a `negative_prompt`, a `seed` (use `-1` to pick a different random seed each time), and a `size` (must be multiples of 64). Use `"random_caption": true` to pick a random caption from the training set each time.
+Individual samples are defined under the `samples` key. Each sample can have a `prompt`, a `negative_prompt`, a `seed` (use `-1` to pick a different random seed each time), and a `size` (must be multiples of 64) or `aspect_ratio` (eg 1.77778 for 16:9). Use `"random_caption": true` to pick a random caption from the training set each time.
 
 ## LR
 

--- a/doc/OPTIMIZER.md
+++ b/doc/OPTIMIZER.md
@@ -34,7 +34,7 @@ Lucidrains' [implementation](https://github.com/lucidrains/lion-pytorch) of the 
 
 LR can be set in `optimizer.json` and excluded from the main CLI arg or train.json but if you use the main CLI arg or set it in the main train.json it will override the setting. This was done to make sure existing behavior will not break.  To set LR in the `optimizer.json` make sure to delete `"lr": 1.3e-6` in your main train.json and exclude the CLI arg.
 
-The text encoder LR can run at a different value to the U-net LR. This may help prevent over-fitting, especially if you're training from SD2 checkpoints. To set the text encoder LR, add a value for `text_encoder_lr_scale` to `optimizer.json`. For example, to have the text encoder LR to 50% of the U-net LR, add `"text_encoder_lr_scale": 0.5` to `optimizer.json`. The default value is `1.0`, meaning the text encoder and U-net are trained with the same LR.
+The text encoder LR can run at a different value to the Unet LR. This may help prevent over-fitting, especially if you're training from SD2 checkpoints. To set the text encoder LR, add a value for `text_encoder_lr_scale` to `optimizer.json`. For example, to train the text encoder with an LR that is half that of the Unet, add `"text_encoder_lr_scale": 0.5` to `optimizer.json`. The default value is `1.0`, meaning the text encoder and Unet are trained with the same LR.
 
 Betas, weight decay, and epsilon are documented in the [AdamW paper](https://arxiv.org/abs/1711.05101) and there is a wealth of information on the web, but consider those experimental to tweak.  I cannot provide advice on what might be useful to tweak here.
 

--- a/doc/OPTIMIZER.md
+++ b/doc/OPTIMIZER.md
@@ -34,6 +34,8 @@ Lucidrains' [implementation](https://github.com/lucidrains/lion-pytorch) of the 
 
 LR can be set in `optimizer.json` and excluded from the main CLI arg or train.json but if you use the main CLI arg or set it in the main train.json it will override the setting. This was done to make sure existing behavior will not break.  To set LR in the `optimizer.json` make sure to delete `"lr": 1.3e-6` in your main train.json and exclude the CLI arg.
 
+The text encoder LR can run at a different value to the U-net LR. This may help prevent over-fitting, especially if you're training from SD2 checkpoints. To set the text encoder LR, add a value for `text_encoder_lr_scale` to `optimizer.json`. For example, to have the text encoder LR to 50% of the U-net LR, add `"text_encoder_lr_scale": 0.5` to `optimizer.json`. The default value is `1.0`, meaning the text encoder and U-net are trained with the same LR.
+
 Betas, weight decay, and epsilon are documented in the [AdamW paper](https://arxiv.org/abs/1711.05101) and there is a wealth of information on the web, but consider those experimental to tweak.  I cannot provide advice on what might be useful to tweak here.
 
 Note `lion` does not use epsilon.

--- a/optimizer.json
+++ b/optimizer.json
@@ -6,7 +6,7 @@
         "betas": "exponential decay rates for the moment estimates",
         "epsilon": "value added to denominator for numerical stability, unused for lion",
         "weight_decay": "weight decay (L2 penalty)",
-        "text_encoder_lr_scale": "if set, scale the text encoder's LR by this much relative to the unet LR"
+        "text_encoder_lr_scale": "scale the text encoder LR relative to the Unet LR. for example, if `lr` is 2e-6 and `text_encoder_lr_scale` is 0.5, the text encoder's LR will be set to `1e-6`."
     },
     "optimizer": "adamw8bit",
     "lr": 1e-6,

--- a/optimizer.json
+++ b/optimizer.json
@@ -5,11 +5,13 @@
         "lr": "learning rate, if null wil use CLI or main JSON config value",
         "betas": "exponential decay rates for the moment estimates",
         "epsilon": "value added to denominator for numerical stability, unused for lion",
-        "weight_decay": "weight decay (L2 penalty)"
+        "weight_decay": "weight decay (L2 penalty)",
+        "text_encoder_lr_scale": "if set, scale the text encoder's LR by this much relative to the unet LR"
     },
     "optimizer": "adamw8bit",
     "lr": 1e-6,
     "betas": [0.9, 0.999],
     "epsilon": 1e-8,
-    "weight_decay": 0.010
+    "weight_decay": 0.010,
+    "text_encoder_lr_scale": 1.0
 }

--- a/train.py
+++ b/train.py
@@ -839,7 +839,7 @@ def main(args):
                     loss_local = sum(loss_log_step) / len(loss_log_step)
                     loss_log_step = []
                     logs = {"loss/log_step": loss_local, "lr": curr_lr, "img/s": images_per_sec}
-                    if args.disable_textenc_training or args.disable_unet_training:
+                    if args.disable_textenc_training or args.disable_unet_training or text_encoder_lr_scale == 1:
                         log_writer.add_scalar(tag="hyperparamater/lr", scalar_value=curr_lr, global_step=global_step)
                     else:
                         log_writer.add_scalar(tag="hyperparamater/lr unet", scalar_value=curr_lr, global_step=global_step)

--- a/train.py
+++ b/train.py
@@ -537,7 +537,7 @@ def main(args):
         logging.info(f"{Fore.CYAN} * Training Text Encoder Only *{Style.RESET_ALL}")
         if text_encoder_lr_scale != 1:
             logging.warning(f"{Fore.YELLOW} * Ignoring text_encoder_lr_scale {text_encoder_lr_scale} and using the "
-                            f"Unet LR {curr_lr} for the text encoder instead.")
+                            f"Unet LR {curr_lr} for the text encoder instead *{Style.RESET_ALL}")
         params_to_train = itertools.chain(text_encoder.parameters())
     else:
         logging.info(f"{Fore.CYAN} * Training Text and Unet *{Style.RESET_ALL}")

--- a/train.py
+++ b/train.py
@@ -520,7 +520,7 @@ def main(args):
 
         text_encoder_lr_scale = optimizer_config.get("text_encoder_lr_scale", text_encoder_lr_scale)
         if text_encoder_lr_scale != 1.0:
-            print(f" * Using text encoder LR scale {text_encoder_lr_scale}")
+            logging.info(f" * Using text encoder LR scale {text_encoder_lr_scale}")
 
         logging.info(f" * Loaded optimizer args from {optimizer_config_path} *")
 

--- a/train.py
+++ b/train.py
@@ -363,7 +363,9 @@ def main(args):
     else:
         from tqdm.auto import tqdm
 
-    seed = args.seed if args.seed != -1 else random.randint(0, 2**30)
+    if args.seed == -1:
+        args.seed = random.randint(0, 2**30)
+    seed = args.seed
     logging.info(f" Seed: {seed}")
     set_seed(seed)
     if torch.cuda.is_available():
@@ -533,6 +535,9 @@ def main(args):
         params_to_train = itertools.chain(unet.parameters())
     elif args.disable_unet_training:
         logging.info(f"{Fore.CYAN} * Training Text Encoder Only *{Style.RESET_ALL}")
+        if text_encoder_lr_scale != 1:
+            logging.warning(f"{Fore.YELLOW} * Ignoring text_encoder_lr_scale {text_encoder_lr_scale} and using the "
+                            f"Unet LR {curr_lr} for the text encoder instead.")
         params_to_train = itertools.chain(text_encoder.parameters())
     else:
         logging.info(f"{Fore.CYAN} * Training Text and Unet *{Style.RESET_ALL}")

--- a/utils/sample_generator.py
+++ b/utils/sample_generator.py
@@ -158,7 +158,7 @@ class SampleGenerator:
             self.num_inference_steps = config.get('num_inference_steps', self.num_inference_steps)
             self.show_progress_bars = config.get('show_progress_bars', self.show_progress_bars)
             self.generate_pretrain_samples = config.get('generate_pretrain_samples', self.generate_pretrain_samples)
-            self.sample_steps = config.get('sample_steps', self.sample_steps)
+            self.sample_steps = config.get('generate_samples_every_n_steps', self.sample_steps)
             sample_requests_config = config.get('samples', None)
             if sample_requests_config is None:
                 self.sample_requests = self._make_random_caption_sample_requests()

--- a/utils/sample_generator.py
+++ b/utils/sample_generator.py
@@ -155,10 +155,22 @@ class SampleGenerator:
             else:
                 default_seed = config.get('seed', self.default_seed)
                 default_size = (self.default_resolution, self.default_resolution)
+                #def make_size_from_aspect_ratio(aspect_ratio):
+                #    if aspect_ratio is None:
+                #        return None
+                #    target_pixel_count = self.default_resolution * self.default_resolution
+                #    w_ratio = aspect_ratio
+                #    h_ratio = 1/w_ratio
+                #    pixels_per_ratio_unit = target_pixel_count/(w_ratio + h_ratio)
+                #    w = round(w_ratio*pixels_per_ratio_unit / 64) * 64
+                #    h = round(h_ratio*pixels_per_ratio_unit / 64) * 64
+                #    return [w,h]
+
+
                 self.sample_requests = [SampleRequest(prompt=p.get('prompt', ''),
                                                       negative_prompt=p.get('negative_prompt', ''),
                                                       seed=p.get('seed', default_seed),
-                                                      size=tuple(p.get('size', default_size)),
+                                                      size=p.get('size', default_size),
                                                       wants_random_caption=p.get('random_caption', False)
                                                       ) for p in sample_requests_config]
             if len(self.sample_requests) == 0:

--- a/utils/sample_generator.py
+++ b/utils/sample_generator.py
@@ -186,6 +186,9 @@ class SampleGenerator:
         except:
             font = ImageFont.load_default()
 
+        if not self.show_progress_bars:
+            print(f" * Generating samples at gs:{global_step} for {len(self.sample_requests)} prompts")
+
         sample_index = 0
         with autocast():
             batch: list[SampleRequest]


### PR DESCRIPTION
* Implement different LR for the text encoder. Control with `text_encoder_lr_scale` in `optimizer.json` (default=1).

i also started making some small tweaks to the sample generator and it kinda got away on me:

* Tidy up validation and sample generator progress bars by properly passing `position` and `leave=False` arguments to `tqdm`.
* Add `aspect_ratio` feature to samples config, to automatically determine an appropriate aspect ratio for the training size. 
* Add `generate_samples_every_n_steps` and `generate_pretrain_samples` to samples config file.
* Improve sample generation logging.
* Update docs
