### PR TITLE
update sleep timer for disconnet

### DIFF
--- a/Train_Colab.ipynb
+++ b/Train_Colab.ipynb
@@ -446,7 +446,7 @@
         "\n",
         "\n",
         "if Disconnect_after_training :\n",
-        "  time.sleep(3)\n",
+        "  time.sleep(40)\n",
         "  runtime.unassign()"
       ]
     },


### PR DESCRIPTION
Discord complaints of last.ckpt not appear may be due to auto disconnect only waiting 3 seconds after training this updates it to 40 which is more then enough time to save to the Gdrive (takes about 28 seconds). This will be safe to accept with out further testing due to only timer being changed.