### PR TITLE
correctly apply `clip_grad_scale` to unscaled gradients

### DIFF
--- a/optimizer/optimizers.py
+++ b/optimizer/optimizers.py
@@ -87,10 +87,13 @@ class EveryDreamOptimizer():
     def step(self, loss, step, global_step):
         self.scaler.scale(loss).backward()
 
-        if self.clip_grad_norm is not None:
-            torch.nn.utils.clip_grad_norm_(parameters=self.unet_params, max_norm=self.clip_grad_norm)
-            torch.nn.utils.clip_grad_norm_(parameters=self.text_encoder_params, max_norm=self.clip_grad_norm)
         if ((global_step + 1) % self.grad_accum == 0) or (step == self.epoch_len - 1):
+            if self.clip_grad_norm is not None:
+                for optimizer in self.optimizers:
+                    self.scaler.unscale_(optimizer)
+                torch.nn.utils.clip_grad_norm_(parameters=self.unet_params, max_norm=self.clip_grad_norm)
+                torch.nn.utils.clip_grad_norm_(parameters=self.text_encoder_params, max_norm=self.clip_grad_norm)
+
             for optimizer in self.optimizers:
                 self.scaler.step(optimizer)
             


### PR DESCRIPTION
currently, if you're using AMP clip_grad_scale is applied to the scaled gradients. this means that you have to pass values like `1e5` or `1e6` for cilp_grad_scale (depending on the state of the AMP scaler), rather than the common/expected `1.0`. moreover, because gradient scaling is dynamic, it's likely the value you pick won't be correct.

this PR makes `--clip_grad_scale` operate on the unscaled gradients instead, meaning you can pass the common/expected value of `1.0` and it will do the right thing (instead of effectively halting training).