### PR TITLE
Anomaly Detection

### DIFF
--- a/optimizer/optimizers.py
+++ b/optimizer/optimizers.py
@@ -84,6 +84,10 @@ class EveryDreamOptimizer():
 
         logging.info(f" Grad scaler enabled: {self.scaler.is_enabled()} (amp mode)")
 
+        if args.abort_on_anomaly:
+            torch.autograd.set_detect_anomaly(True)
+            logging.info("Anomaly detection enabled")
+
     def step(self, loss, step, global_step):
         self.scaler.scale(loss).backward()
 

--- a/train.py
+++ b/train.py
@@ -589,7 +589,7 @@ def main(args):
                 logging.error(f"{Fore.LIGHTRED_EX} CTRL-C received, attempting to save model to {interrupted_checkpoint_path}{Style.RESET_ALL}")
                 logging.error(f"{Fore.LIGHTRED_EX} ************************************************************************{Style.RESET_ALL}")
                 time.sleep(2) # give opportunity to ctrl-C again to cancel save
-                __save_model(interrupted_checkpoint_path, unet, text_encoder, tokenizer, noise_scheduler, vae, optimizer, args.save_ckpt_dir, args.save_full_precision, args.save_optimizer)
+                __save_model(interrupted_checkpoint_path, unet, text_encoder, tokenizer, noise_scheduler, vae, ed_optimizer, args.save_ckpt_dir, args.save_full_precision, args.save_optimizer)
             exit(_SIGTERM_EXIT_CODE)
         else:
             # non-main threads (i.e. dataloader workers) should exit cleanly

--- a/train.py
+++ b/train.py
@@ -900,8 +900,8 @@ if __name__ == "__main__":
     argparser.add_argument("--rated_dataset", action="store_true", default=False, help="enable rated image set training, to less often train on lower rated images through the epochs")
     argparser.add_argument("--rated_dataset_target_dropout_percent", type=int, default=50, help="how many images (in percent) should be included in the last epoch (Default 50)")
     argparser.add_argument("--zero_frequency_noise_ratio", type=float, default=0.02, help="adds zero frequency noise, for improving contrast (def: 0.0) use 0.0 to 0.15")
-
-    # load CLI args to overwrite existing config args
+    argparser.add_argument("--abort_on_anomaly", action="store_true", default=False, help="abort training if an 
+                           anomaly is detected (def: False)")
     args = argparser.parse_args(args=argv, namespace=args)
     
     main(args)


### PR DESCRIPTION
Added in torch anomaly detection. Will automatically abort a run when a NaN or other funny business propagates through the network. Defaulted to `False` as it causes some non-negligible slowdown, but it is very useful for sweeps and the like.