### PR TITLE
User defined batching

### DIFF
--- a/data/aspects.py
+++ b/data/aspects.py
@@ -248,7 +248,7 @@ def __get_all_aspects():
            ]
 
 
-def get_rational_aspect_ratio(bucket_wh: Tuple[int]) -> Tuple[int]:
+def get_rational_aspect_ratio(bucket_wh: Tuple[int, int]) -> Tuple[int]:
     def farey_aspect_ratio_pair(x: float, max_denominator_value: int):
         if x <= 1:
             return farey_aspect_ratio_pair_lt1(x, max_denominator_value)

--- a/data/data_loader.py
+++ b/data/data_loader.py
@@ -147,7 +147,7 @@ class DataLoaderMultiAspect():
         for batch_id in batch_ids:
             items_by_batch_id[batch_id] = unchunk([b for bucket_key,b in buckets.items() if bucket_key[0] == batch_id])
         # ensure we don't mix and match aspect ratios by treating each chunk of batch_size images as a single unit to pass to first_fit_decreasing
-        filler_items = chunk(items_by_batch_id[DEFAULT_BATCH_ID], batch_size)
+        filler_items = chunk(items_by_batch_id.get(DEFAULT_BATCH_ID, []), batch_size)
         custom_batched_items = [chunk(v, batch_size) for k, v in items_by_batch_id.items() if k != DEFAULT_BATCH_ID]
         #custom_batched_items = chunk([b for bucket_key,b in buckets.items() if bucket_key[0] != DEFAULT_BATCH_ID], batch_size)
         neighbourly_chunked_items = first_fit_decreasing(custom_batched_items, batch_size=grad_accum, filler_items=filler_items)

--- a/data/data_loader.py
+++ b/data/data_loader.py
@@ -107,28 +107,16 @@ class DataLoaderMultiAspect():
         buckets = {}
         batch_size = self.batch_size
 
-        def append_to_bucket(item, batch_id):
-            bucket_key = (batch_id, item.target_wh[0], item.target_wh[1])
-            if bucket_key not in buckets:
-                buckets[bucket_key] = []
-            buckets[bucket_key].append(item)
-
         for image_caption_pair in picked_images:
             image_caption_pair.runt_size = 0
             batch_id = image_caption_pair.batch_id
-            append_to_bucket(image_caption_pair, batch_id)
-
-        # shunt any runts from "named" buckets into the appropriate "general" buckets
-        for bucket in [b for b in buckets if b[0] != DEFAULT_BATCH_ID]:
-            truncate_count = len(buckets[bucket]) % batch_size
-            for runt in buckets[bucket][-truncate_count:]:
-                append_to_bucket(runt, DEFAULT_BATCH_ID)
-            del buckets[bucket][-truncate_count:]
-            if len(buckets[bucket]) == 0:
-                del buckets[bucket]
+            bucket_key = (batch_id, image_caption_pair.target_wh[0], image_caption_pair.target_wh[1])
+            if bucket_key not in buckets:
+                buckets[bucket_key] = []
+            buckets[bucket_key].append(image_caption_pair)
 
         # handle runts in "general" buckets by randomly duplicating items
-        for bucket in [b for b in buckets if b[0] == DEFAULT_BATCH_ID]:
+        for bucket in buckets:
             truncate_count = len(buckets[bucket]) % batch_size
             if truncate_count > 0:
                 runt_bucket = buckets[bucket][-truncate_count:]

--- a/data/data_loader.py
+++ b/data/data_loader.py
@@ -21,7 +21,10 @@ import math
 import copy
 
 import random
-from data.image_train_item import ImageTrainItem
+from itertools import groupby
+from typing import Tuple, List
+
+from data.image_train_item import ImageTrainItem, DEFAULT_BATCH_ID
 import PIL.Image
 
 PIL.Image.MAX_IMAGE_PIXELS = 715827880*4 # increase decompression bomb error limit to 4x default
@@ -103,15 +106,29 @@ class DataLoaderMultiAspect():
 
         buckets = {}
         batch_size = self.batch_size
+
+        def append_to_bucket(item, batch_id):
+            bucket_key = (batch_id, item.target_wh[0], item.target_wh[1])
+            if bucket_key not in buckets:
+                buckets[bucket_key] = []
+            buckets[bucket_key].append(item)
+
         for image_caption_pair in picked_images:
             image_caption_pair.runt_size = 0
-            target_wh = image_caption_pair.target_wh
+            batch_id = image_caption_pair.batch_id
+            append_to_bucket(image_caption_pair, batch_id)
 
-            if (target_wh[0],target_wh[1]) not in buckets:
-                buckets[(target_wh[0],target_wh[1])] = []
-            buckets[(target_wh[0],target_wh[1])].append(image_caption_pair)
+        # shunt any runts from "named" buckets into the appropriate "general" buckets
+        for bucket in [b for b in buckets if b[0] != DEFAULT_BATCH_ID]:
+            truncate_count = len(buckets[bucket]) % batch_size
+            for runt in buckets[bucket][-truncate_count:]:
+                append_to_bucket(runt, DEFAULT_BATCH_ID)
+            del buckets[bucket][-truncate_count:]
+            if len(buckets[bucket]) == 0:
+                del buckets[bucket]
 
-        for bucket in buckets:
+        # handle runts in "general" buckets by randomly duplicating items
+        for bucket in [b for b in buckets if b[0] == DEFAULT_BATCH_ID]:
             truncate_count = len(buckets[bucket]) % batch_size
             if truncate_count > 0:
                 runt_bucket = buckets[bucket][-truncate_count:]
@@ -131,6 +148,7 @@ class DataLoaderMultiAspect():
             items.extend(buckets[bucket])
 
         return items
+
 
     def __pick_random_subset(self, dropout_fraction: float, picker: random.Random) -> list[ImageTrainItem]:
         """
@@ -175,3 +193,5 @@ class DataLoaderMultiAspect():
         for item in self.prepared_train_data:
             self.rating_overall_sum += item.caption.rating()
             self.ratings_summed.append(self.rating_overall_sum)
+
+

--- a/data/image_train_item.py
+++ b/data/image_train_item.py
@@ -124,7 +124,7 @@ class ImageTrainItem:
     flip_p: probability of flipping image (0.0 to 1.0)
     rating: the relative rating of the images. The rating is measured in comparison to the other images.
     """
-    def __init__(self, 
+    def __init__(self,
                  image: PIL.Image, 
                  caption: ImageCaption, 
                  aspects: list[float], 
@@ -133,6 +133,7 @@ class ImageTrainItem:
                  multiplier: float=1.0, 
                  cond_dropout=None,
                  shuffle_tags=False,
+                 batch_id: str=None
                  ):
         self.caption = caption
         self.aspects = aspects
@@ -143,6 +144,8 @@ class ImageTrainItem:
         self.multiplier = multiplier
         self.cond_dropout = cond_dropout
         self.shuffle_tags = shuffle_tags
+        self.batch_id = batch_id or DEFAULT_BATCH_ID
+        self.target_wh = None
 
         self.image_size = None
         if image is None or len(image) == 0:
@@ -351,3 +354,6 @@ class ImageTrainItem:
             image = image.crop((x_crop, y_crop, x_crop + min_xy, y_crop + min_xy))
 
         return image
+
+
+DEFAULT_BATCH_ID = "default_batch"

--- a/doc/ADVANCED_TWEAKING.md
+++ b/doc/ADVANCED_TWEAKING.md
@@ -153,11 +153,13 @@ Very tentatively, I suggest closer to 0.10 for short term training, and lower va
 
 ## Keeping images together (custom batching)
 
-If you have a subset of your dataset that expresses the same style or concept, training quality may be improved by putting all of these images through the trainer in the same batch every step (rather than the default behaviour, which is to shuffle them randomly throughout the entire dataset).
+If you have a subset of your dataset that expresses the same style or concept, training quality may be improved by putting all of these images through the trainer together in the same batch or batches, instead of the default behaviour (which is to shuffle them randomly throughout the entire dataset).
 
-To control this, put a file called `batch_id.txt` in each batch with a unique name for the data. For example if you have a bunch of images of horses and you are trying to train them as a single concept, you can assign a batch id such as "my_horses" to these images by putting the word `my_horses` inside `batch_id.txt` in your folder with horse images. 
+To control this, put a file called `batch_id.txt` into a folder to give a unique name to the training data in this folder. For example, if you have a bunch of images of horses and you are trying to train them as a single concept, you can assign a unique name such as "my_horses" to these images by putting the word `my_horses` inside `batch_id.txt` in your folder with horse images. 
 
 > Note that because this creates extra aspect ratio buckets, you need to be very careful about correlating the number of images to your training batch size. Aim to have an exact multiple of `batch_size` images at each aspect ratio. For example, if your `batch_size` is 6 and you have images with aspect ratios 4:3, 3:4, and 9:16, you should add or delete images until you have an exact multiple of 6 images (i.e. 6, 12, 28, ...) for each aspect ratio. If you do not do this, the bucketer will duplicate images to fill up each aspect ratio bucket. You'll probably also want to use manual validation to prevent the validator from messing this up, too.
+
+If you are using `.yaml` files for captioning, you can alternatively add a `batch_id: ` entry to either `local.yaml` or the individual images' `.yaml` files. Note that neither `.yaml` nor `batch_id.txt` files act recursively: they do not apply to subfolders.
 
 
 # Stuff you probably don't need to mess with, but well here it is:

--- a/doc/ADVANCED_TWEAKING.md
+++ b/doc/ADVANCED_TWEAKING.md
@@ -151,6 +151,15 @@ Test results: https://huggingface.co/panopstor/ff7r-stable-diffusion/blob/main/z
 
 Very tentatively, I suggest closer to 0.10 for short term training, and lower values of around 0.02 to 0.03 for longer runs (50k+ steps).  Early indications seem to suggest values like 0.10 can cause divergance over time. 
 
+## Keeping images together (custom batching)
+
+If you have a subset of your dataset that expresses the same style or concept, training quality may be improved by putting all of these images through the trainer in the same batch every step (rather than the default behaviour, which is to shuffle them randomly throughout the entire dataset).
+
+To control this, put a file called `batch_id.txt` in each batch with a unique name for the data. For example if you have a bunch of images of horses and you are trying to train them as a single concept, you can assign a batch id such as "my_horses" to these images by putting the word `my_horses` inside `batch_id.txt` in your folder with horse images. 
+
+> Note that because this creates extra aspect ratio buckets, you need to be very careful about correlating the number of images to your training batch size. Aim to have an exact multiple of `batch_size` images at each aspect ratio. For example, if your `batch_size` is 6 and you have images with aspect ratios 4:3, 3:4, and 9:16, you should add or delete images until you have an exact multiple of 6 images (i.e. 6, 12, 28, ...) for each aspect ratio. If you do not do this, the bucketer will duplicate images to fill up each aspect ratio bucket. You'll probably also want to use manual validation to prevent the validator from messing this up, too.
+
+
 # Stuff you probably don't need to mess with, but well here it is:
 
 

--- a/test/test_first_fit_decreasing.py
+++ b/test/test_first_fit_decreasing.py
@@ -4,7 +4,7 @@ from utils.first_fit_decreasing import first_fit_decreasing
 
 class TestFirstFitDecreasing(unittest.TestCase):
 
-    def test_basic(self):
+    def test_single_basic(self):
         input = [[1, 2, 3, 4, 5, 6]]
         output = first_fit_decreasing(input, batch_size=2)
         self.assertEqual(output, [1, 2, 3, 4, 5, 6])
@@ -20,3 +20,62 @@ class TestFirstFitDecreasing(unittest.TestCase):
         input = [[1, 2, 3]]
         output = first_fit_decreasing(input, batch_size=4)
         self.assertEqual(output, [1, 2, 3])
+
+    def test_multi_basic(self):
+        input = [[1, 1, 1, 1], [2, 2]]
+        output = first_fit_decreasing(input, batch_size=2)
+        self.assertEqual(output, [1, 1, 1, 1, 2, 2])
+
+        input = [[1, 1, 1, 1], [2, 2]]
+        output = first_fit_decreasing(input, batch_size=3)
+        self.assertEqual(output, [1, 1, 1, 2, 2, 1])
+
+        input = [[1, 1, 1, 1], [2, 2]]
+        output = first_fit_decreasing(input, batch_size=4)
+        self.assertEqual(output, [1, 1, 1, 1, 2, 2])
+
+        input = [[1, 1], [2, 2]]
+        output = first_fit_decreasing(input, batch_size=4)
+        self.assertEqual(output, [2, 2, 1, 1])
+
+    def test_multi_complex(self):
+        input = [[1, 1, 1, 1], [2, 2], [3, 3, 3]]
+        output = first_fit_decreasing(input, batch_size=2)
+        self.assertEqual(output, [1, 1, 3, 3, 1, 1, 2, 2, 3])
+
+        input = [[1, 1, 1, 1], [2, 2], [3, 3, 3]]
+        output = first_fit_decreasing(input, batch_size=3)
+        self.assertEqual(output, [1, 1, 1, 3, 3, 3, 2, 2, 1])
+
+        input = [[1, 1, 1, 1], [2, 2], [3, 3, 3]]
+        output = first_fit_decreasing(input, batch_size=4)
+        self.assertEqual(output, [1, 1, 1, 1, 3, 3, 3, 2, 2])
+
+        input = [[1, 1], [2, 2], [3, 3, 3]]
+        output = first_fit_decreasing(input, batch_size=4)
+        self.assertEqual(output, [3, 3, 3, 2, 1, 1, 2])
+
+        input = [[1, 1, 1, 1], [2, 2, 2], [3, 3, 3], [4, 4, 4], [5, 5]]
+        output = first_fit_decreasing(input, batch_size=4)
+        self.assertEqual(output, [1, 1, 1, 1, 4, 4, 4, 3, 2, 2, 2, 3, 5, 5, 3])
+
+    def test_filler_bucket(self):
+        input = [[1, 1, 1, 1], [2, 2]]
+        output = first_fit_decreasing(input, batch_size=2, filler_items=[9, 9])
+        self.assertEqual(output, [1, 1, 1, 1, 2, 2, 9, 9])
+
+        input = [[1, 1, 1, 1], [2, 2]]
+        output = first_fit_decreasing(input, batch_size=3, filler_items=[9, 9])
+        self.assertEqual(output, [1, 1, 1, 2, 2, 9, 1, 9])
+
+        input = [[1, 1, 1, 1], [2, 2]]
+        output = first_fit_decreasing(input, batch_size=4, filler_items=[9, 9])
+        self.assertEqual(output, [1, 1, 1, 1, 2, 2, 9, 9])
+
+        input = [[1, 1], [2, 2]]
+        output = first_fit_decreasing(input, batch_size=4, filler_items=[9, 9])
+        self.assertEqual(output, [2, 2, 9, 9, 1, 1])
+
+        input = [[1, 1, 1, 1], [2, 2, 2], [3, 3, 3], [4, 4, 4], [5, 5]]
+        output = first_fit_decreasing(input, batch_size=4, filler_items=[9, 9])
+        self.assertEqual(output, [1, 1, 1, 1, 4, 4, 4, 9, 3, 3, 3, 9, 2, 2, 2, 5, 5])

--- a/test/test_first_fit_decreasing.py
+++ b/test/test_first_fit_decreasing.py
@@ -1,0 +1,22 @@
+import unittest
+
+from utils.first_fit_decreasing import first_fit_decreasing
+
+class TestFirstFitDecreasing(unittest.TestCase):
+
+    def test_basic(self):
+        input = [[1, 2, 3, 4, 5, 6]]
+        output = first_fit_decreasing(input, batch_size=2)
+        self.assertEqual(output, [1, 2, 3, 4, 5, 6])
+
+        input = [[1, 2, 3, 4, 5, 6]]
+        output = first_fit_decreasing(input, batch_size=3)
+        self.assertEqual(output, [1, 2, 3, 4, 5, 6])
+
+        input = [[1, 2, 3, 4, 5, 6]]
+        output = first_fit_decreasing(input, batch_size=4)
+        self.assertEqual(output, [1, 2, 3, 4, 5, 6])
+
+        input = [[1, 2, 3]]
+        output = first_fit_decreasing(input, batch_size=4)
+        self.assertEqual(output, [1, 2, 3])

--- a/train.py
+++ b/train.py
@@ -552,6 +552,7 @@ def main(args):
         image_train_items=image_train_items,
         seed=seed,
         batch_size=args.batch_size,
+        grad_accum=args.grad_accum
     )
 
     train_batch = EveryDreamBatch(

--- a/utils/first_fit_decreasing.py
+++ b/utils/first_fit_decreasing.py
@@ -1,16 +1,63 @@
+import copy
 from typing import List
 
-def first_fit_decreasing(input_list: List[List], batch_size: int) -> List:
+def first_fit_decreasing(input_items: List[List], batch_size: int, filler_items: List=[]) -> List:
     """
     Given as input a list of lists, batch the items so that as much as possible the members of each of the original
-    lists end up in the same batch.
+    lists end up in the same batch. Pad out too-short batches by taking items from the filler_items list, if available.
 
-    @return a list of batches
+    @return flattened list of all items in input_items and filler_items, arranged such that, as much as possible, items
+        that are in the same input list end up in the same batch.
     """
 
-    def sort_by_length(items: List[List]):
-        return items.sort(key=lambda x: len(x), reverse=True)
+    def sort_by_length(items: List[List]) -> List[List]:
+        return sorted(items, key=lambda x: len(x))
 
-    remaining = list(input_list)
+    remaining = copy.deepcopy(input_items)
+    output = []
     while remaining:
         remaining = sort_by_length(remaining)
+        longest = remaining.pop()
+        if len(longest) == 0:
+            continue
+        if len(longest) >= batch_size:
+            output.append(longest[0:batch_size])
+            del longest[0:batch_size]
+            if len(longest)>0:
+                remaining.append(longest)
+        else:
+            # need to build this chunk by combining multiple
+            combined = copy.deepcopy(longest)
+            while True:
+                fill_length = batch_size - len(combined)
+                if fill_length == 0:
+                    break
+
+                if len(remaining) == 0 and len(filler_items) == 0:
+                    break
+
+                from_filler_bucket = filler_items[0:fill_length]
+                if len(from_filler_bucket) > 0:
+                    del filler_items[0:fill_length]
+                    combined.extend(from_filler_bucket)
+                    continue
+
+                filler = next((r for r in remaining if len(r) <= fill_length), None)
+                if filler is not None:
+                    remaining.remove(filler)
+                    combined.extend(filler)
+                else:
+                    # steal from the next longest
+                    next_longest = remaining.pop()
+                    combined.extend(next_longest[0:fill_length])
+                    del next_longest[0:fill_length]
+                    if len(next_longest) > 0:
+                        remaining.append(next_longest)
+            output.append(combined)
+
+    output.append(filler_items)
+    return [i for o in output for i in o]
+
+
+
+

--- a/utils/first_fit_decreasing.py
+++ b/utils/first_fit_decreasing.py
@@ -13,7 +13,7 @@ def first_fit_decreasing(input_items: List[List], batch_size: int, filler_items:
     def sort_by_length(items: List[List]) -> List[List]:
         return sorted(items, key=lambda x: len(x))
 
-    remaining = copy.deepcopy(input_items)
+    remaining = input_items
     output = []
     while remaining:
         remaining = sort_by_length(remaining)
@@ -27,7 +27,7 @@ def first_fit_decreasing(input_items: List[List], batch_size: int, filler_items:
                 remaining.append(longest)
         else:
             # need to build this chunk by combining multiple
-            combined = copy.deepcopy(longest)
+            combined = longest
             while True:
                 fill_length = batch_size - len(combined)
                 if fill_length == 0:

--- a/utils/first_fit_decreasing.py
+++ b/utils/first_fit_decreasing.py
@@ -1,0 +1,16 @@
+from typing import List
+
+def first_fit_decreasing(input_list: List[List], batch_size: int) -> List:
+    """
+    Given as input a list of lists, batch the items so that as much as possible the members of each of the original
+    lists end up in the same batch.
+
+    @return a list of batches
+    """
+
+    def sort_by_length(items: List[List]):
+        return items.sort(key=lambda x: len(x), reverse=True)
+
+    remaining = list(input_list)
+    while remaining:
+        remaining = sort_by_length(remaining)


### PR DESCRIPTION
Add a `batch_id.txt` file containing a batch id string to a subfolder (or add a `batch_id` key to `local.yaml`) to cause images sharing the same batch id to be processed together. 