### PR TITLE
misc small fixes

### DIFF
--- a/data/data_loader.py
+++ b/data/data_loader.py
@@ -253,6 +253,8 @@ def chunked_shuffle(l: List, chunk_size: int, randomizer: random.Random) -> List
     Shuffles l in chunks, preserving the chunk boundaries and the order of items within each chunk.
     If the last chunk is incomplete, it is not shuffled (i.e. preserved as the last chunk)
     """
+    if len(l) == 0:
+        return []
 
     # chunk by effective batch size
     chunks = chunk(l, chunk_size)

--- a/data/data_loader.py
+++ b/data/data_loader.py
@@ -124,7 +124,7 @@ class DataLoaderMultiAspect():
                 continue
             runts = bucket[-runt_count:]
             del bucket[-runt_count:]
-            matching_default_bucket_key = [DEFAULT_BATCH_ID, key[1], key[2]]
+            matching_default_bucket_key = (DEFAULT_BATCH_ID, key[1], key[2])
             buckets[matching_default_bucket_key].extend(runts)
 
         # handle remaining runts by randomly duplicating items

--- a/data/data_loader.py
+++ b/data/data_loader.py
@@ -125,6 +125,8 @@ class DataLoaderMultiAspect():
             runts = bucket[-runt_count:]
             del bucket[-runt_count:]
             matching_default_bucket_key = (DEFAULT_BATCH_ID, key[1], key[2])
+            if matching_default_bucket_key not in buckets:
+                buckets[matching_default_bucket_key] = []
             buckets[matching_default_bucket_key].extend(runts)
 
         # handle remaining runts by randomly duplicating items

--- a/data/every_dream_validation.py
+++ b/data/every_dream_validation.py
@@ -97,7 +97,8 @@ class EveryDreamValidator:
             self.config.update({'manual_data_root': self.config['val_data_root']})
 
         if self.config.get('val_split_mode') == 'manual':
-            if 'manual_data_root' in self.config:
+            manual_data_root = self.config.get('manual_data_root')
+            if manual_data_root is not None:
                 self.config['extra_manual_datasets'].update({'val': self.config['manual_data_root']})
             else:
                 if len(self.config['extra_manual_datasets']) == 0:

--- a/data/every_dream_validation.py
+++ b/data/every_dream_validation.py
@@ -97,9 +97,12 @@ class EveryDreamValidator:
             self.config.update({'manual_data_root': self.config['val_data_root']})
 
         if self.config.get('val_split_mode') == 'manual':
-            if 'manual_data_root' not in self.config:
-                raise ValueError("Error in validation config .json: 'manual' validation is missing 'manual_data_root'")
-            self.config['extra_manual_datasets'].update({'val': self.config['manual_data_root']})
+            if 'manual_data_root' in self.config:
+                self.config['extra_manual_datasets'].update({'val': self.config['manual_data_root']})
+            else:
+                if len(self.config['extra_manual_datasets']) == 0:
+                    raise ValueError("Error in validation config .json: 'manual' validation requested but no "
+                                     "'manual_data_root' or 'extra_manual_datasets'")
 
         if 'val_split_proportion' in self.config:
             logging.warning(f"   * {Fore.YELLOW}using old name 'val_split_proportion' for 'auto_split_proportion' - please "

--- a/utils/sample_generator.py
+++ b/utils/sample_generator.py
@@ -176,7 +176,7 @@ class SampleGenerator:
                                                       wants_random_caption=p.get('random_caption', False)
                                                       ) for p in sample_requests_config]
             if len(self.sample_requests) == 0:
-                self._make_random_caption_sample_requests()
+                self.sample_requests = self._make_random_caption_sample_requests()
 
     @torch.no_grad()
     def generate_samples(self, pipe: StableDiffusionPipeline, global_step: int):


### PR DESCRIPTION
a few improvements to batch shuffling and validation

* fix a bug where an empty `samples.txt` was not populated with random samples
* fix a shuffling bug handling rare aspect ratios: non-named batches are now shuffled better, preventing clustering of rare aspect ratios at the end of the epoch (symptom: "random caption" samples were often repeated if sampling steps == epoch length)
* better named batch runt handling: named batch runts in a given epoch are dynamically demoted to the DEFAULT_BATCH_ID for that epoch, preventing over-duplication
* permit `null` for `manual_data_root` for `manual` validation if there are entries `extra_manual_datasets`
* when using `extra_manual_datasets`, also log a mean of all validation losses to `loss/_all_val_combined`