### PR TITLE
same flags Damian would like

### DIFF
--- a/optimizer.json
+++ b/optimizer.json
@@ -42,5 +42,6 @@
         "freeze_embeddings": false,
         "freeze_front_n_layers": null,
         "freeze_final_layer_norm": false
-    }
+    },
+    "apply_grad_scaler_step_tweaks": true
 }

--- a/optimizer/optimizers.py
+++ b/optimizer/optimizers.py
@@ -56,6 +56,7 @@ class EveryDreamOptimizer():
 
         self.grad_accum = args.grad_accum
         self.clip_grad_norm = args.clip_grad_norm
+        self.apply_grad_scaler_step_tweaks = optimizer_config.get("apply_grad_scaler_step_tweaks", True)
 
         self.text_encoder_params = self._apply_text_encoder_freeze(text_encoder)
         self.unet_params = unet.parameters()
@@ -103,7 +104,8 @@ class EveryDreamOptimizer():
         for scheduler in self.lr_schedulers:
             scheduler.step()
 
-        self._update_grad_scaler(global_step)
+        if self.apply_grad_scaler_step_tweaks:
+            self._update_grad_scaler(global_step)
 
     def _zero_grad(self, set_to_none=False):
         for optimizer in self.optimizers:


### PR DESCRIPTION
with this patch you can
* pass `--no_prepend_last` to prevent ED from renaming the last save to `last-<name>`
* pass `--no_save_ckpt` to disable ckpt saving (diffusers format models are still saved)
* add `"apply_grad_scaler_step_tweaks": false` to optimizer.json to prevent ED from tweaking the grad scaling (which seems to be disruptive when training SD2)

also, the final epoch save is low labelled `ep<max_epochs>` rather than `ep<max_epochs-1>`