### PR TITLE
Fix Inaccuracies in Image Size Validation and Warning Display

### DIFF
--- a/data/image_train_item.py
+++ b/data/image_train_item.py
@@ -314,8 +314,10 @@ class ImageTrainItem:
                 image_aspect = width / height
                 target_wh = min(self.aspects, key=lambda aspects:abs(aspects[0]/aspects[1] - image_aspect))
 
-                self.is_undersized = (width * height) < (target_wh[0]*1.02 * target_wh[1]*1.02)
+                self.is_undersized = (width != target_wh[0] and height != target_wh[1]) and (width * height) < (target_wh[0]*1.02 * target_wh[1]*1.02)
+
                 self.target_wh = target_wh
+                self.image_size = image.size
         except Exception as e:
             self.error = e
 

--- a/test/test_image_train_item.py
+++ b/test/test_image_train_item.py
@@ -4,6 +4,7 @@ import pathlib
 import PIL.Image as Image
 
 from data.image_train_item import ImageCaption, ImageTrainItem
+import data.aspects as aspects
 
 DATA_PATH = pathlib.Path('./test/data')
 
@@ -33,3 +34,69 @@ class TestImageCaption(unittest.TestCase):
         
         caption = ImageCaption("hello world", 1.0, [], [], 2048, False)
         self.assertEqual(caption.get_caption(), "hello world")
+
+class TestImageTrainItemConstructor(unittest.TestCase):
+    
+    def tearDown(self) -> None:
+        for file in DATA_PATH.glob("img_*"):
+            file.unlink()
+
+        return super().tearDown()
+
+    @staticmethod 
+    def image_with_size(width, height):
+        filename = DATA_PATH / "img_{}x{}.jpg".format(width, height)
+        Image.new("RGB", (width, height)).save(filename)
+        caption = ImageCaption("hello world", 1.0, [], [], 2048, False)
+        return ImageTrainItem(None, caption, aspects.ASPECTS_512, filename, 0.0, 1.0, False, False, 0)
+           
+    def test_target_size_computation(self):
+        # Square images
+        image = self.image_with_size(30, 30)
+        self.assertEqual(image.target_wh, [512,512])
+        self.assertTrue(image.is_undersized)
+        self.assertEqual(image.image_size, (30,30))
+
+        image = self.image_with_size(512, 512)
+        self.assertEqual(image.target_wh, [512,512])
+        self.assertFalse(image.is_undersized)
+        self.assertEqual(image.image_size, (512,512))
+
+        image = self.image_with_size(580, 580)
+        self.assertEqual(image.target_wh, [512,512])
+        self.assertFalse(image.is_undersized)
+        self.assertEqual(image.image_size, (580,580))
+
+        # Landscape images
+        image = self.image_with_size(64, 38)
+        self.assertEqual(image.target_wh, [640,384])
+        self.assertTrue(image.is_undersized)
+        self.assertEqual(image.image_size, (64,38))
+
+        image = self.image_with_size(640, 384)
+        self.assertEqual(image.target_wh, [640,384])
+        self.assertFalse(image.is_undersized)
+        self.assertEqual(image.image_size, (640,384))
+
+        image = self.image_with_size(704, 422)
+        self.assertEqual(image.target_wh, [640,384])
+        self.assertFalse(image.is_undersized)
+        self.assertEqual(image.image_size, (704,422))
+
+        # Portrait images
+        image = self.image_with_size(38, 64)
+        self.assertEqual(image.target_wh, [384,640])
+        self.assertTrue(image.is_undersized)
+        self.assertEqual(image.image_size, (38,64))
+
+        image = self.image_with_size(384, 640)
+        self.assertEqual(image.target_wh, [384,640])
+        self.assertFalse(image.is_undersized)
+        self.assertEqual(image.image_size, (384,640))
+
+        image = self.image_with_size(422, 704)
+        self.assertEqual(image.target_wh, [384,640])
+        self.assertFalse(image.is_undersized)
+        self.assertEqual(image.image_size, (422,704))
+
+        


### PR DESCRIPTION
## Summary:
This PR addresses two issues related to image size detection and warning messages:

- Eliminates the warning message when the target image dimensions align with the training resolution.
- Correctly writes the image dimensions instead of `None` for undersized images.

## Problem Description:
Prior to this fix, the system incorrectly flags a target image as "undersized" when its dimensions are exactly the same as the training resolution. For instance, with a training resolution of 512, a 512x512 target image triggers the following entry in the undersize log:

```
... target_image.png with size: None is smaller than target size: [512, 512]
```