### PR TITLE
Textual Inversion plugin

### DIFF
--- a/optimizer/optimizers.py
+++ b/optimizer/optimizers.py
@@ -445,9 +445,8 @@ class EveryDreamOptimizer():
             unfreeze_last_n_layers = num_layers
         else:
             # something specified:
-            assert(unfreeze_last_n_layers > 0)
             if unfreeze_last_n_layers < num_layers:
-                # if we're unfreezing layers then by default we ought to freeze the embeddings
+                # if we're freezing any layers then by default we ought to freeze the embeddings
                 unfreeze_embeddings = False
 
         if "freeze_embeddings" in self.te_freeze_config:

--- a/optimizer/optimizers.py
+++ b/optimizer/optimizers.py
@@ -147,7 +147,14 @@ class EveryDreamOptimizer():
         if args.disable_textenc_training:
             optimizer_te = None
         else:
-            optimizer_te = self._create_optimizer("text encoder", args, self.te_config, text_encoder_params)
+            # prevent OOM on TE-only training
+            if args.disable_unet_training:
+                for p in unet_params:
+                    p.requires_grad = False
+                params_to_use = itertools.chain(unet_params, text_encoder_params)
+            else:
+                params_to_use = text_encoder_params
+            optimizer_te = self._create_optimizer("text encoder", args, self.te_config, params_to_use)
         if args.disable_unet_training:
             optimizer_unet = None
         else:

--- a/plugins/plugins.py
+++ b/plugins/plugins.py
@@ -9,6 +9,8 @@ class BasePlugin:
         pass
     def on_epoch_end(self, **kwargs):
         pass
+    def on_model_load(self, **kwargs):
+        pass
     def on_training_start(self, **kwargs):
         pass
     def on_training_end(self, **kwargs):
@@ -59,6 +61,11 @@ class PluginRunner:
         self.epoch_warn_seconds = epoch_warn_seconds
         self.step_warn_seconds = step_warn_seconds
         self.training_warn_seconds = training_warn_seconds
+
+    def run_on_model_load(self, **kwargs):
+        for plugin in self.plugins:
+            with Timer(warn_seconds=self.epoch_warn_seconds, label=f'{plugin.__class__.__name__}'):
+                plugin.on_model_load(**kwargs)
 
     def run_on_epoch_end(self, **kwargs):
         for plugin in self.plugins:

--- a/plugins/plugins.py
+++ b/plugins/plugins.py
@@ -3,6 +3,8 @@ import importlib
 import logging
 import time
 import warnings
+from typing import Optional
+
 
 class BasePlugin:
     def on_epoch_start(self, **kwargs):
@@ -52,6 +54,7 @@ class Timer:
 
 
 class PluginRunner:
+
     def __init__(self, plugins: list, epoch_warn_seconds=5, step_warn_seconds=0.5, training_warn_seconds=20):
         """
         plugins: list of plugins to run
@@ -59,6 +62,10 @@ class PluginRunner:
         step_warn_seconds: warn if any step start/end call takes longer than this
         training_warn_seconds: warn if any training start/end call take longer than this
         """
+        global g_plugin_runner
+        if g_plugin_runner is not None:
+            raise RuntimeError("Multiple PluginRunner instances created - this is not supported")
+        g_plugin_runner = self
         self.plugins = plugins
         self.epoch_warn_seconds = epoch_warn_seconds
         self.step_warn_seconds = step_warn_seconds
@@ -103,3 +110,7 @@ class PluginRunner:
         for plugin in self.plugins:
             with Timer(warn_seconds=self.step_warn_seconds, label=f'{plugin.__class__.__name__}'):
                 plugin.on_step_end(**kwargs)
+
+
+g_plugin_runner: Optional[PluginRunner] = None
+

--- a/plugins/plugins.py
+++ b/plugins/plugins.py
@@ -67,6 +67,11 @@ class PluginRunner:
             with Timer(warn_seconds=self.epoch_warn_seconds, label=f'{plugin.__class__.__name__}'):
                 plugin.on_model_load(**kwargs)
 
+    def run_on_model_save(self, **kwargs):
+        for plugin in self.plugins:
+            with Timer(warn_seconds=self.epoch_warn_seconds, label=f'{plugin.__class__.__name__}'):
+                plugin.on_model_save(**kwargs)
+
     def run_on_epoch_end(self, **kwargs):
         for plugin in self.plugins:
             with Timer(warn_seconds=self.epoch_warn_seconds, label=f'{plugin.__class__.__name__}'):

--- a/plugins/plugins.py
+++ b/plugins/plugins.py
@@ -11,6 +11,8 @@ class BasePlugin:
         pass
     def on_model_load(self, **kwargs):
         pass
+    def on_model_save(self, **kwargs):
+        pass
     def on_training_start(self, **kwargs):
         pass
     def on_training_end(self, **kwargs):

--- a/plugins/plugins.py
+++ b/plugins/plugins.py
@@ -55,6 +55,12 @@ class Timer:
 
 class PluginRunner:
 
+    _instance: 'PluginRunner' = None
+
+    @classmethod
+    def get_global_instance(cls) -> 'PluginRunner':
+        return cls._instance
+
     def __init__(self, plugins: list, epoch_warn_seconds=5, step_warn_seconds=0.5, training_warn_seconds=20):
         """
         plugins: list of plugins to run
@@ -62,10 +68,10 @@ class PluginRunner:
         step_warn_seconds: warn if any step start/end call takes longer than this
         training_warn_seconds: warn if any training start/end call take longer than this
         """
-        global g_plugin_runner
-        if g_plugin_runner is not None:
+        if self.__class__._instance is not None:
             raise RuntimeError("Multiple PluginRunner instances created - this is not supported")
-        g_plugin_runner = self
+        self.__class__._instance = self
+
         self.plugins = plugins
         self.epoch_warn_seconds = epoch_warn_seconds
         self.step_warn_seconds = step_warn_seconds
@@ -110,7 +116,4 @@ class PluginRunner:
         for plugin in self.plugins:
             with Timer(warn_seconds=self.step_warn_seconds, label=f'{plugin.__class__.__name__}'):
                 plugin.on_step_end(**kwargs)
-
-
-g_plugin_runner: Optional[PluginRunner] = None
 

--- a/plugins/textual_inversion.json
+++ b/plugins/textual_inversion.json
@@ -5,6 +5,7 @@
   },
   "tokens": [
     { "token": "hat*", "initializer_word": "hat" },
-    { "token": "dancing shoes", "initializer_word": "shoes" }
+    { "token": "dancing shoes", "initializer_word": "shoes" },
+    { "token": "cane", "initializer_word": "cane" }
   ]
 }

--- a/plugins/textual_inversion.json
+++ b/plugins/textual_inversion.json
@@ -1,0 +1,10 @@
+
+{
+  "documentation": {
+    "tokens": "a list of token - initializer_word pairs defining textual inversion tokens to train, and their initial values. tokens can be multi-word, but they must be written in captions exactly the given if the training is to have any effect. initializer_word should be already close to the target being trained, but it must tokenize to a single token."
+  },
+  "tokens": [
+    { "token": "hat*", "initializer_word": "hat" },
+    { "token": "dancing shoes", "initializer_word": "shoes" }
+  ]
+}

--- a/plugins/textual_inversion.json
+++ b/plugins/textual_inversion.json
@@ -1,7 +1,8 @@
 
 {
   "documentation": {
-    "tokens": "a list of token - initializer_word pairs defining textual inversion tokens to train, and their initial values. tokens can be multi-word, but they must be written in captions exactly the given if the training is to have any effect. initializer_word should be already close to the target being trained, but it must tokenize to a single token."
+    "tokens": "a list of token - initializer_word pairs defining textual inversion tokens to train, and their initial values. tokens can be multi-word, but they must be written in captions exactly the given if the training is to have any effect. initializer_word should be already close to the target being trained, but it must tokenize to a single token.",
+    "example": "the example below trains `hat*`, `dancing shoes` and `cane` as custom tokens, if you have training data where the captions include those tokens."
   },
   "tokens": [
     { "token": "hat*", "initializer_word": "hat" },

--- a/plugins/textual_inversion.py
+++ b/plugins/textual_inversion.py
@@ -1,0 +1,83 @@
+import json
+import logging
+import os.path
+
+import torch
+from colorama import Fore
+
+from plugins.plugins import BasePlugin
+from train import EveryDreamTrainingState
+
+""" config file format:
+
+{
+  'tokens': [
+    { 'token': 'hat*', 'initializer': 'hat' },
+    { 'token': 'dancing shoes', 'initializer_word': 'shoes' }, # multi word string ok
+  ]
+}
+"""
+
+class TextualInversionPlugin(BasePlugin):
+
+    def __init__(self):
+        path = os.path.join(os.path.dirname(__file__), "textual_inversion.json")
+        print(f"Textual Inversion plugin instantiated, loading data from {path}...")
+        with open(path, 'rt') as f:
+            self.config = json.load(f)
+
+    def on_model_load(self, **kwargs):
+        ed_state: EveryDreamTrainingState = kwargs.get('ed_state')
+        optimizer_config: dict = kwargs.get('optimizer_config')
+
+        # check for correctly configured text encoder training
+        num_te_layers = len(ed_state.text_encoder.text_model.encoder.layers)
+        if (optimizer_config is None or
+            'text_encoder_freezing' not in optimizer_config or
+            optimizer_config['text_encoder_freezing'].get('freeze_embeddings') != False or
+            optimizer_config['text_encoder_freezing'].get('unfreeze_last_n_layers', 0) < num_te_layers
+        ):
+            required_js_fragment = {"text_encoder_freezing": {"freeze_embeddings": False, "unfreeze_last_n_layers": num_te_layers}}
+            logging.error(f" * {Fore.LIGHTRED_EX}Textual Inversion plugin REQUIRES the following json fragment in your optimizer config:{Fore.RESET}")
+            logging.error(f" * {Fore.LIGHTRED_EX}  {json.dumps(required_js_fragment)}{Fore.RESET}")
+            raise RuntimeError("Misconfigured optimizer config")
+
+        tokens_to_add = [t['token'] for t in self.config['tokens']]
+        num_added_tokens = ed_state.tokenizer.add_tokens(tokens_to_add)
+        if num_added_tokens != len(tokens_to_add):
+            raise RuntimeError(f"Tokens not added successfully - tried to add {len(tokens_to_add)} but only added {num_added_tokens}")
+        ed_state.text_encoder.resize_token_embeddings(len(ed_state.tokenizer))
+
+        added_token_ids = []
+        input_embeddings = ed_state.text_encoder.get_input_embeddings()
+        for token_info in self.config['tokens']:
+            # get newly added token id
+            t = token_info['token']
+            token_ids = ed_state.tokenizer.convert_tokens_to_ids(ed_state.tokenizer.tokenize(t))
+            if len(token_ids) != 1:
+                raise RuntimeError(f"Tokens not added succesfully - expected 1 token id for {t}, found {len(token_ids)}")
+            token_id = token_ids[0]
+            added_token_ids.append(token_id)
+
+            # copy initializer embedding
+            initializer_word = token_info['initializer_word']
+            initializer_word_token_ids = ed_state.tokenizer.convert_tokens_to_ids(ed_state.tokenizer.tokenize(initializer_word))
+            if len(initializer_word_token_ids) != 1:
+                raise RuntimeError(f"Tokens not added succesfully - initializer word '{initializer_word}' needs "
+                                   f"{len(initializer_word_token_ids)} tokens, but only single tokens are supported.")
+            initializer_word_token_id = initializer_word_token_ids[0]
+            initializer_embedding = input_embeddings.weight.data[initializer_word_token_id]
+            input_embeddings.weight.data[token_id] = initializer_embedding
+
+        self.added_token_ids = added_token_ids
+        self.original_text_embeddings = ed_state.text_encoder.get_input_embeddings().weight.data.detach().clone()
+
+
+    def on_step_end(self, **kwargs):
+        ed_state: EveryDreamTrainingState = kwargs['ed_state']
+        # reset all embeddings except the ones we're training to their original state
+        index_no_updates = torch.isin(torch.arange(len(ed_state.tokenizer)), torch.Tensor(self.added_token_ids))
+        with (torch.no_grad()):
+            ed_state.text_encoder.get_input_embeddings().weight[
+                index_no_updates
+            ] = self.original_text_embeddings[index_no_updates]

--- a/plugins/textual_inversion.py
+++ b/plugins/textual_inversion.py
@@ -29,6 +29,8 @@ class TextualInversionPlugin(BasePlugin):
     def on_model_load(self, **kwargs):
         ed_state: EveryDreamTrainingState = kwargs.get('ed_state')
         optimizer_config: dict = kwargs.get('optimizer_config')
+        def get_token_ids(t: str):
+            return ed_state.tokenizer.convert_tokens_to_ids(ed_state.tokenizer.tokenize(t))
 
         # check for correctly configured text encoder training
         num_te_layers = len(ed_state.text_encoder.text_model.encoder.layers)
@@ -42,7 +44,13 @@ class TextualInversionPlugin(BasePlugin):
             logging.error(f" * {Fore.LIGHTRED_EX}  {json.dumps(required_js_fragment)}{Fore.RESET}")
             raise RuntimeError("Misconfigured optimizer config")
 
-        tokens_to_add = [t['token'] for t in self.config['tokens']]
+        tokens_to_add = [t['token'] for t in self.config['tokens'] if len(get_token_ids(t['token']))>1]
+        logging.info(
+            f" * Textual inversion training adding the following tokens: {tokens_to_add}")
+        tokens_to_overwrite = [t['token'] for t in self.config['tokens'] if t['token'] not in tokens_to_add]
+        if any(tokens_to_overwrite):
+            logging.warning(f" * {Fore.LIGHTYELLOW_EX}Textual inversion training overwriting the following tokens: {tokens_to_overwrite}{Fore.RESET}")
+
         num_added_tokens = ed_state.tokenizer.add_tokens(tokens_to_add)
         if num_added_tokens != len(tokens_to_add):
             raise RuntimeError(f"Tokens not added successfully - tried to add {len(tokens_to_add)} but only added {num_added_tokens}")
@@ -53,7 +61,7 @@ class TextualInversionPlugin(BasePlugin):
         for token_info in self.config['tokens']:
             # get newly added token id
             t = token_info['token']
-            token_ids = ed_state.tokenizer.convert_tokens_to_ids(ed_state.tokenizer.tokenize(t))
+            token_ids = get_token_ids(t)
             if len(token_ids) != 1:
                 raise RuntimeError(f"Tokens not added succesfully - expected 1 token id for {t}, found {len(token_ids)}")
             token_id = token_ids[0]
@@ -61,7 +69,7 @@ class TextualInversionPlugin(BasePlugin):
 
             # copy initializer embedding
             initializer_word = token_info['initializer_word']
-            initializer_word_token_ids = ed_state.tokenizer.convert_tokens_to_ids(ed_state.tokenizer.tokenize(initializer_word))
+            initializer_word_token_ids = get_token_ids(initializer_word)
             if len(initializer_word_token_ids) != 1:
                 raise RuntimeError(f"Tokens not added succesfully - initializer word '{initializer_word}' needs "
                                    f"{len(initializer_word_token_ids)} tokens, but only single tokens are supported.")
@@ -69,14 +77,19 @@ class TextualInversionPlugin(BasePlugin):
             initializer_embedding = input_embeddings.weight.data[initializer_word_token_id]
             input_embeddings.weight.data[token_id] = initializer_embedding
 
-        self.added_token_ids = added_token_ids
+        overwriting_token_ids = [get_token_ids(t)[0] for t in tokens_to_overwrite]
+        self.training_token_ids = added_token_ids + overwriting_token_ids
         self.original_text_embeddings = ed_state.text_encoder.get_input_embeddings().weight.data.detach().clone()
 
 
     def on_step_end(self, **kwargs):
         ed_state: EveryDreamTrainingState = kwargs['ed_state']
         # reset all embeddings except the ones we're training to their original state
-        index_no_updates = torch.isin(torch.arange(len(ed_state.tokenizer)), torch.Tensor(self.added_token_ids))
+        index_no_updates = torch.isin(
+            torch.arange(len(ed_state.tokenizer)),
+            torch.Tensor(self.training_token_ids),
+            invert=True
+        )
         with (torch.no_grad()):
             ed_state.text_encoder.get_input_embeddings().weight[
                 index_no_updates

--- a/plugins/textual_inversion.py
+++ b/plugins/textual_inversion.py
@@ -26,7 +26,7 @@ In optimizer.json, the following "text_encoder_freezing" section is *required*:
         "freeze_embeddings": false,
         "freeze_final_layer_norm": true
     }
-In addition, you'll need a very high LR on the TE - start with 1e-4.
+In addition, you'll need a very high LR on the TE - maybe even as high as 1e-3. I recommend using the LR finder method.
 
 """
 

--- a/train.py
+++ b/train.py
@@ -764,6 +764,7 @@ def main(args):
         with open(os.path.join(os.curdir, optimizer_config_path), "r") as f:
             optimizer_config = json.load(f)
 
+    global plugin_runner
     plugin_runner = PluginRunner(plugins=plugins)
     plugin_runner.run_on_model_load(
         ed_state=EveryDreamTrainingState(unet=unet, text_encoder=text_encoder, tokenizer=tokenizer, vae=vae),


### PR DESCRIPTION
With this plugin you can target specific token embeddings in the text encoder, and/or add new ones. The embeddings get written into the model's text encoder and saved out - not the most efficient way to share them, but useful if you want to laser-focus training of specific or custom tokens in your model.

Documentation (such as it is) is in `plugins/textual_inversion.py`. TL;DR is - edit `plugins/textual_inversion.json` to set up your tokens and initialization states, freeze all TE layers and TE final layer norm, and use a very high LR for the TE - my last test worked best at 1.5e-3. You'll probably also want to freeze unet training.

Also included @Freon, i think i figured out why i was getting OOM with disabling the unet training. This PR includes logic that explicitly sets `requires_grad = False` for all parameters not being trained.