### PR TITLE
Update CLOUD_SETUP.md

### DIFF
--- a/doc/CLOUD_SETUP.md
+++ b/doc/CLOUD_SETUP.md
@@ -4,6 +4,8 @@
 
 Click here -> [EveryDream2 template](https://runpod.io/gsc?template=d1v63jb36t&ref=bbp9dh8x) to load a fully configured Docker image.  Both Tensorboard and Jupyter lab are automatically started for you and you can simply click the links to connect.
 
+**IMPORTANT**: This will only work on the Community Cloud, not the Secure Cloud!
+
 If you wish to sign up for Runpod, please consider using this [referral link](https://runpod.io?ref=oko38cd0) to help support the project.  2% of your spend is given back in the form of credits back to the project and costs you nothing.
 
 You can also [enable full SSH support](https://www.runpod.io/blog/how-to-achieve-true-ssh-on-runpod) by setting the PUBLIC_KEY environment variable


### PR DESCRIPTION
Tell people that the secure cloud option for RunPod.io no longer works, and they must use the community cloud.