### PR TITLE
Feat textual inversion plugin v2

### DIFF
--- a/plugins/plugins.py
+++ b/plugins/plugins.py
@@ -92,7 +92,17 @@ class PluginRunner:
         for plugin in self.plugins:
             with Timer(warn_seconds=self.step_warn_seconds, label=f'{plugin.__class__.__name__}'):
                 plugin.on_step_end(**kwargs)
-    
+
+    def run_on_model_load(self, **kwargs):
+        for plugin in self.plugins:
+            with Timer(warn_seconds=self.epoch_warn_seconds, label=f'{plugin.__class__.__name__}'):
+                plugin.on_model_load(**kwargs)
+
+    def run_on_model_save(self, **kwargs):
+        for plugin in self.plugins:
+            with Timer(warn_seconds=self.epoch_warn_seconds, label=f'{plugin.__class__.__name__}'):
+                plugin.on_model_save(**kwargs)
+
     def run_transform_caption(self, caption):
         with Timer(warn_seconds=self.step_warn_seconds, label="plugin.transform_caption"):
             for plugin in self.plugins:

--- a/plugins/plugins.py
+++ b/plugins/plugins.py
@@ -18,6 +18,10 @@ class BasePlugin:
         pass
     def on_step_end(self, **kwargs):
         pass
+    def on_model_load(self, **kwargs):
+        pass
+    def on_model_save(self, **kwargs):
+        pass
     def on_will_step_optimizer(self, **kwargs):
         pass
     def transform_caption(self, caption:str) -> str:

--- a/plugins/plugins.py
+++ b/plugins/plugins.py
@@ -18,6 +18,8 @@ class BasePlugin:
         pass
     def on_step_end(self, **kwargs):
         pass
+    def on_will_step_optimizer(self, **kwargs):
+        pass
     def transform_caption(self, caption:str):
         return caption
     def transform_pil_image(self, img:Image):
@@ -92,6 +94,11 @@ class PluginRunner:
         for plugin in self.plugins:
             with Timer(warn_seconds=self.step_warn_seconds, label=f'{plugin.__class__.__name__}'):
                 plugin.on_step_end(**kwargs)
+
+    def run_on_backpropagation(self, **kwargs):
+        for plugin in self.plugins:
+            with Timer(warn_seconds=self.step_warn_seconds, label=f'{plugin.__class__.__name__}'):
+                plugin.on_backpropagation(**kwargs)
 
     def run_on_model_load(self, **kwargs):
         for plugin in self.plugins:

--- a/plugins/plugins.py
+++ b/plugins/plugins.py
@@ -20,10 +20,12 @@ class BasePlugin:
         pass
     def on_will_step_optimizer(self, **kwargs):
         pass
-    def transform_caption(self, caption:str):
+    def transform_caption(self, caption:str) -> str:
         return caption
-    def transform_pil_image(self, img:Image):
+    def transform_pil_image(self, img:Image) -> Image:
         return img
+    def modify_sample_prompt(self, prompt:str) -> str:
+        return prompt
 
 def load_plugin(plugin_path):
     print(f" - Attempting to load plugin: {plugin_path}")
@@ -102,12 +104,12 @@ class PluginRunner:
 
     def run_on_model_load(self, **kwargs):
         for plugin in self.plugins:
-            with Timer(warn_seconds=self.epoch_warn_seconds, label=f'{plugin.__class__.__name__}'):
+            with Timer(warn_seconds=self.training_warn_seconds, label=f'{plugin.__class__.__name__}'):
                 plugin.on_model_load(**kwargs)
 
     def run_on_model_save(self, **kwargs):
         for plugin in self.plugins:
-            with Timer(warn_seconds=self.epoch_warn_seconds, label=f'{plugin.__class__.__name__}'):
+            with Timer(warn_seconds=self.training_warn_seconds, label=f'{plugin.__class__.__name__}'):
                 plugin.on_model_save(**kwargs)
 
     def run_transform_caption(self, caption):
@@ -121,3 +123,9 @@ class PluginRunner:
             for plugin in self.plugins:
                 img = plugin.transform_pil_image(img)
         return img
+
+    def run_modify_sample_prompt(self, prompt) -> str:
+        with Timer(warn_seconds=self.step_warn_seconds, label="plugin.modify_sample_prompt"):
+            for plugin in self.plugins:
+                prompt = plugin.modify_sample_prompt(prompt)
+        return prompt

--- a/plugins/plugins.py
+++ b/plugins/plugins.py
@@ -22,7 +22,7 @@ class BasePlugin:
         pass
     def on_model_save(self, **kwargs):
         pass
-    def on_will_step_optimizer(self, **kwargs):
+    def on_backpropagation(self, **kwargs):
         pass
     def transform_caption(self, caption:str) -> str:
         return caption

--- a/plugins/textual_inversion.json
+++ b/plugins/textual_inversion.json
@@ -1,0 +1,16 @@
+
+{
+  "documentation": {
+    "tokens": {
+      "token": "the token (word) to train, given exactly as it appears in tokens",
+      "initializer_word": "starting point for the embedding. make it close to the intended meaning to kick-start training",
+      "vector_length": "length of the embedding. use more if you have more images and/or if what you want to train is complex"
+    },
+    "example": "the example below trains `hat*`, `dancing shoes` and `cane` as custom tokens, if you have training data where the captions include those tokens."
+  },
+  "tokens": [
+    { "token": "hat*", "initializer_word": "hat", "vector_length": 8 },
+    { "token": "dancing shoes", "initializer_word": "shoes" },
+    { "token": "cane", "initializer_word": "cane" }
+  ]
+}

--- a/plugins/textual_inversion.json
+++ b/plugins/textual_inversion.json
@@ -8,9 +8,13 @@
     },
     "example": "the example below trains `hat*`, `dancing shoes` and `cane` as custom tokens, if you have training data where the captions include those tokens."
   },
-  "tokens": [
+  "example_tokens": [
     { "token": "hat*", "initializer": "a man's hat", "vector_length": 8 },
     { "token": "dancing shoes", "initializer": "shoes" },
     { "token": "cane", "initializer": "cane" }
+  ],
+  "tokens": [
+    { "token": "ay hairstyle", "initializer": "long red hair, elaborately plaited", "vector_length": 18 },
+    { "token": "hz outfit", "initializer": "skins, furs, and pieces of ceramic, plastic, and alloy plating", "vector_length": 18 }
   ]
 }

--- a/plugins/textual_inversion.json
+++ b/plugins/textual_inversion.json
@@ -8,13 +8,9 @@
     },
     "example": "the example below trains `hat*`, `dancing shoes` and `cane` as custom tokens, if you have training data where the captions include those tokens."
   },
-  "example_tokens": [
+  "tokens": [
     { "token": "hat*", "initializer": "a man's hat", "vector_length": 8 },
     { "token": "dancing shoes", "initializer": "shoes" },
     { "token": "cane", "initializer": "cane" }
-  ],
-  "tokens": [
-    { "token": "ay hairstyle", "initializer": "long red hair, elaborately plaited", "vector_length": 18 },
-    { "token": "hz outfit", "initializer": "skins, furs, and pieces of ceramic, plastic, and alloy plating", "vector_length": 18 }
   ]
 }

--- a/plugins/textual_inversion.json
+++ b/plugins/textual_inversion.json
@@ -3,14 +3,14 @@
   "documentation": {
     "tokens": {
       "token": "the token (word) to train, given exactly as it appears in tokens",
-      "initializer_word": "starting point for the embedding. make it close to the intended meaning to kick-start training",
-      "vector_length": "length of the embedding. use more if you have more images and/or if what you want to train is complex"
+      "initializer": "starting point for the embedding. make it close to the intended meaning to kick-start training. should be shorter (in tokens) than the vector_length.",
+      "vector_length": "length of the embedding (default 1). use more if you have more images and/or if what you want to train is complex."
     },
     "example": "the example below trains `hat*`, `dancing shoes` and `cane` as custom tokens, if you have training data where the captions include those tokens."
   },
   "tokens": [
-    { "token": "hat*", "initializer_word": "hat", "vector_length": 8 },
-    { "token": "dancing shoes", "initializer_word": "shoes" },
-    { "token": "cane", "initializer_word": "cane" }
+    { "token": "hat*", "initializer": "a man's hat", "vector_length": 8 },
+    { "token": "dancing shoes", "initializer": "shoes" },
+    { "token": "cane", "initializer": "cane" }
   ]
 }

--- a/plugins/textual_inversion.py
+++ b/plugins/textual_inversion.py
@@ -133,6 +133,7 @@ class TextualInversionPlugin(BasePlugin):
         for token_id, token in zip(self.training_token_ids, self.training_tokens):
             _save_embedding(token=token, embedding=embeddings.weight[token_id], save_folder=save_folder)
 
+
 def _save_embedding(token, embedding, save_folder):
     dict_to_save = {token: embedding}
     token_name_safe = clean_filename(token)

--- a/plugins/textual_inversion.py
+++ b/plugins/textual_inversion.py
@@ -29,9 +29,10 @@ In optimizer.json, the following "text_encoder_freezing" section is *required*:
         "freeze_final_layer_norm": true,
         "freeze_position_embeddings": true
     }
-In addition, you'll need a very high LR on the TE - maybe even as high as 1e-3. I recommend using the LR finder method.
+In addition, you'll need a very high LR on the TE - maybe even as high as 5e-2. I recommend using the LR finder method.
 
 """
+
 
 class TextualInversionPlugin(BasePlugin):
 

--- a/plugins/textual_inversion.py
+++ b/plugins/textual_inversion.py
@@ -6,6 +6,8 @@ import torch
 from colorama import Fore
 import re
 
+from transformers import CLIPTextModel, CLIPTokenizer
+
 from plugins.plugins import BasePlugin
 from train import EveryDreamTrainingState
 from utils.sample_generator import clean_filename
@@ -33,6 +35,67 @@ In addition, you'll need a very high LR on the TE - maybe even as high as 5e-2. 
 
 """
 
+class TextualInversionLoaderPlugin(BasePlugin):
+    def __init__(self):
+        path = os.path.join(os.path.dirname(__file__), "textual_inversion_loader.json")
+        logging.info(f" * Textual Inversion plugin instantiated, loading config from {path}")
+        with open(path, 'rt') as f:
+            self.config = json.load(f)
+        self.padding_tokens = {}
+
+    def on_model_load(self, **kwargs):
+        ed_state: EveryDreamTrainingState = kwargs['ed_state']
+        resume_ckpt: str = kwargs['resume_ckpt']
+        #self.original_tokens_length = len(ed_state.tokenizer)
+        tokenizer = ed_state.tokenizer
+
+        token_config = self.config['tokens']
+
+        embeddings = {}
+        for token_info in self.config['tokens']:
+            token = token_info["token"]
+            path = token_info.get("path", None) or _get_embedding_path(resume_ckpt, token)
+            with open(path, "rb") as f:
+                embedding_dict = torch.load(f)
+                embedding = list(embedding_dict.values())[0]
+                embeddings[token] = embedding
+            token_info["vector_length"] = embedding.shape[0]
+            print(f" * Textual Inversion Loader loaded embedding with vector length {token_info['vector_length']} for token '{token}' from {path}")
+
+        training_tokens, padding_tokens, tokens_to_add, tokens_to_overwrite = (
+            _setup_tokens(text_encoder=ed_state.text_encoder, tokenizer=ed_state.tokenizer, token_infos=token_config))
+        self.padding_tokens = padding_tokens
+
+        input_embeddings = ed_state.text_encoder.get_input_embeddings()
+        for token_info in self.config['tokens']:
+            token = token_info["token"]
+            vector_length = token_info["vector_length"]
+            trigger_and_padding_tokens = [token] + padding_tokens[token]
+            embedding = embeddings[token]
+            for i in range(vector_length):
+                token_ids = _get_token_ids(tokenizer, trigger_and_padding_tokens[i])
+                token_id = token_ids[0]
+                input_embeddings.weight.data[token_id] = embedding[i]
+
+
+    def transform_caption(self, caption:str) -> str:
+        return self.expand_trigger_tokens(caption)
+
+    def modify_sample_prompt(self, prompt: str) -> str:
+        return self.expand_trigger_tokens(prompt)
+
+    def expand_trigger_tokens(self, caption: str) -> str:
+        tokens = self.config['tokens']
+        # for multi-vector tokens, replace the trigger token with a padded sequence of the correct length.
+        # eg "hat*" with vector length 3 -> "hat* hat*_pad!!!_1 hat*_pad!!!_2"
+        for t in tokens:
+            trigger = t['token']
+            replacement = " ".join([trigger] + self.padding_tokens[trigger])
+            caption = re.sub(trigger, replacement, caption)
+        return caption
+
+
+
 
 class TextualInversionPlugin(BasePlugin):
 
@@ -50,15 +113,14 @@ class TextualInversionPlugin(BasePlugin):
 
     def on_model_load(self, **kwargs):
         ed_state: EveryDreamTrainingState = kwargs.get('ed_state')
-        def get_token_ids(t: str):
-            return ed_state.tokenizer.convert_tokens_to_ids(ed_state.tokenizer.tokenize(t))
+        tokenizer = ed_state.tokenizer
 
         # check for correctly configured text encoder training
         disable_unet_training: bool = kwargs.get('disable_unet_training')
         disable_textenc_training: bool = kwargs.get('disable_textenc_training')
-        #if not disable_unet_training or disable_textenc_training:
-        #    logging.error(f" * {Fore.LIGHTRED_EX}Textual Inversion plugin REQUIRES {Fore.RESET}\"disable_unet_training\": true{Fore.LIGHTRED_EX} and {Fore.RESET}\"disable_textenc_training\": false{Fore.LIGHTRED_EX} in your train.json{Fore.RESET}")
-        #    raise RuntimeError("Unet training must be disabled and text encoder training enabled")
+        if not disable_unet_training or disable_textenc_training:
+            logging.error(f" * {Fore.LIGHTRED_EX}Textual Inversion plugin REQUIRES {Fore.RESET}\"disable_unet_training\": true{Fore.LIGHTRED_EX} and {Fore.RESET}\"disable_textenc_training\": false{Fore.LIGHTRED_EX} in your train.json{Fore.RESET}")
+            raise RuntimeError("Unet training must be disabled and text encoder training enabled")
         num_te_layers = len(ed_state.text_encoder.text_model.encoder.layers)
         optimizer_config: dict = kwargs.get('optimizer_config')
         if (optimizer_config is None or
@@ -72,69 +134,57 @@ class TextualInversionPlugin(BasePlugin):
             logging.error(f" * {Fore.LIGHTRED_EX}  {json.dumps(required_js_fragment)}{Fore.RESET}")
             raise RuntimeError("Misconfigured optimizer config")
 
-
-        training_tokens = set()
-        for token_info in self.config['tokens']:
-            start_token = token_info['token']
-            vector_length = token_info.get('vector_length', 1)
+        for token_info in self.config["tokens"]:
+            start_token = token_info["token"]
+            vector_length = token_info.get("vector_length", 1)
             print(f" * Textual Inversion training on '{start_token}' with vector length {vector_length}")
-            this_padding_tokens = [f"{start_token}_pad!!!_{n+1}" for n in range(vector_length-1)]
-            self.padding_tokens[start_token] = this_padding_tokens
-            training_tokens.update([start_token] + this_padding_tokens)
 
-        tokens_to_add = [t for t in training_tokens if len(get_token_ids(t))>1]
+
+        training_tokens, padding_tokens, tokens_to_add, tokens_to_overwrite = (
+            _setup_tokens(text_encoder=ed_state.text_encoder, tokenizer=ed_state.tokenizer, token_infos=self.config['tokens']))
+        self.padding_tokens = padding_tokens
+        for trigger_token, padding_tokens in padding_tokens.items():
+            this_padding_token_ids = [_get_token_ids(tokenizer, t)[0] for t in padding_tokens]
+            self.padding_token_ids[trigger_token] = this_padding_token_ids
+
         logging.info(
             f" * Textual inversion training adding the following tokens: {sorted(tokens_to_add)}")
-        tokens_to_overwrite = [t for t in training_tokens if t not in tokens_to_add]
         if any(tokens_to_overwrite):
             logging.warning(f" * {Fore.LIGHTYELLOW_EX}Textual inversion training overwriting the following tokens: {tokens_to_overwrite}{Fore.RESET}")
-
-        num_added_tokens = ed_state.tokenizer.add_tokens(tokens_to_add)
-        if num_added_tokens != len(tokens_to_add):
-            raise RuntimeError(f"Tokens not added successfully - tried to add {len(tokens_to_add)} but only added {num_added_tokens}")
-        ed_state.text_encoder.resize_token_embeddings(len(ed_state.tokenizer))
-
-        added_token_ids = []
-        for token in tokens_to_add:
-            token_ids = get_token_ids(token)
-            if len(token_ids) != 1:
-                raise RuntimeError(f"Tokens not added succesfully - expected 1 token id for {token}, found {len(token_ids)}")
-            token_id = token_ids[0]
-            added_token_ids.append(token_id)
-
-        for trigger_token, padding_tokens in self.padding_tokens.items():
-            this_padding_token_ids = [get_token_ids(t)[0] for t in padding_tokens]
-            self.padding_token_ids[trigger_token] = this_padding_token_ids
 
         # copy initializer embedding
         input_embeddings = ed_state.text_encoder.get_input_embeddings()
         for token_info in self.config['tokens']:
             vector_length = token_info.get('vector_length', 1)
             # make sure it's very long
-            initializer_text = " ".join([token_info['initializer']] * vector_length)
-            with torch.no_grad():
-                initializer_token_ids_full = ed_state.tokenizer(initializer_text,
-                               truncation=True,
-                               padding="max_length",
-                               max_length=ed_state.tokenizer.model_max_length,
-                               ).input_ids
-                initializer_embedding_full = ed_state.text_encoder(
-                    torch.tensor(initializer_token_ids_full, device=ed_state.text_encoder.device).unsqueeze(0), output_hidden_states=True
-                ).last_hidden_state
-            initializer_embedding = initializer_embedding_full[0][1:vector_length+1]
+            initializer_text = None if token_info.get('random_initializer', True) else " ".join([token_info['initializer']] * vector_length)
+            if initializer_text is None:
+                reference = input_embeddings.weight[0]
+                embedding_length = reference.shape[0]
+                initializer_embedding = torch.rand([vector_length, embedding_length],
+                                                   dtype=reference.dtype,
+                                                   device=reference.device) * 0.1 - 0.05
+            else:
+                with torch.no_grad():
+                    initializer_token_ids_full = ed_state.tokenizer(initializer_text,
+                                   truncation=True,
+                                   padding="max_length",
+                                   max_length=ed_state.tokenizer.model_max_length,
+                                   ).input_ids
+                    initializer_embedding_full = ed_state.text_encoder(
+                        torch.tensor(initializer_token_ids_full, device=ed_state.text_encoder.device).unsqueeze(0), output_hidden_states=True
+                    ).last_hidden_state
+                initializer_embedding = initializer_embedding_full[0][1:vector_length+1]
 
             trigger_token = token_info['token']
             trigger_and_padding_tokens = [trigger_token] + self.padding_tokens[trigger_token]
             for i in range(vector_length):
-                token_ids = get_token_ids(trigger_and_padding_tokens[i])
+                token_ids = _get_token_ids(tokenizer, trigger_and_padding_tokens[i])
                 token_id = token_ids[0]
-                # don't clobber trained embeddings when resuming
-                if token_id in tokens_to_add:
-                    input_embeddings.weight.data[token_id] = initializer_embedding[i]
+                input_embeddings.weight.data[token_id] = initializer_embedding[i]
 
-        overwriting_token_ids = [get_token_ids(t)[0] for t in tokens_to_overwrite]
         self.training_tokens = tokens_to_add + tokens_to_overwrite
-        self.training_token_ids = added_token_ids + overwriting_token_ids
+        self.training_token_ids = [_get_token_ids(tokenizer, t)[0] for t in self.training_tokens]
 
         # get indices of non-training tokens (ie tokens whose grads should be reset to 0 every step)
         total_len = len(ed_state.text_encoder.get_input_embeddings().weight)
@@ -188,10 +238,44 @@ class TextualInversionPlugin(BasePlugin):
 
 def _save_embedding(token, embedding, save_folder):
     dict_to_save = {token: embedding}
-    token_name_safe = clean_filename(token)
-    ti_folder = os.path.join(save_folder, 'textual_inversions')
-    os.makedirs(ti_folder, exist_ok=True)
-    save_path = os.path.join(ti_folder, token_name_safe + '.bin')
+    save_path = _get_embedding_path(save_folder, token)
+    os.makedirs(os.path.dirname(save_path), exist_ok=True)
     logging.info(f"Saving textual inversion for '{token}' to {save_path}")
     torch.save(dict_to_save, save_path)
 
+def _get_embedding_path(save_folder: str, token: str) -> str:
+    token_name_safe = clean_filename(token)
+    ti_folder = os.path.join(save_folder, 'textual_inversions')
+    return os.path.join(ti_folder, token_name_safe + '.bin')
+
+def _setup_tokens(tokenizer: CLIPTokenizer, text_encoder: CLIPTextModel, token_infos: list[dict]) -> tuple[set, dict, list, list]:
+    training_tokens = set()
+    padding_tokens = {}
+    for token_info in token_infos:
+        start_token = token_info['token']
+        vector_length = token_info.get('vector_length', 1)
+        this_padding_tokens = [f"{start_token}_pad!!!_{n + 1}" for n in range(vector_length - 1)]
+        padding_tokens[start_token] = this_padding_tokens
+        training_tokens.update([start_token] + this_padding_tokens)
+
+    tokens_to_add = [t for t in training_tokens if len(_get_token_ids(tokenizer, t)) > 1]
+    tokens_to_overwrite = [t for t in training_tokens if t not in tokens_to_add]
+
+    num_added_tokens = tokenizer.add_tokens(tokens_to_add)
+    if num_added_tokens != len(tokens_to_add):
+        raise RuntimeError(f"Tokens not added successfully - tried to add {len(tokens_to_add)} but only added {num_added_tokens}")
+    text_encoder.resize_token_embeddings(len(tokenizer))
+
+    added_token_ids = []
+    for token in tokens_to_add:
+        token_ids = _get_token_ids(tokenizer, token)
+        if len(token_ids) != 1:
+            raise RuntimeError(f"Tokens not added succesfully - expected 1 token id for {token}, found {len(token_ids)}")
+        token_id = token_ids[0]
+        added_token_ids.append(token_id)
+
+    return training_tokens, padding_tokens, tokens_to_add, tokens_to_overwrite
+
+
+def _get_token_ids(tokenizer, t: str):
+    return tokenizer.convert_tokens_to_ids(tokenizer.tokenize(t))

--- a/plugins/textual_inversion.py
+++ b/plugins/textual_inversion.py
@@ -129,7 +129,9 @@ class TextualInversionPlugin(BasePlugin):
             for i in range(vector_length):
                 token_ids = get_token_ids(trigger_and_padding_tokens[i])
                 token_id = token_ids[0]
-                input_embeddings.weight.data[token_id] = initializer_embedding[i]
+                # don't clobber trained embeddings when resuming
+                if token_id in tokens_to_add:
+                    input_embeddings.weight.data[token_id] = initializer_embedding[i]
 
         overwriting_token_ids = [get_token_ids(t)[0] for t in tokens_to_overwrite]
         self.training_tokens = tokens_to_add + tokens_to_overwrite

--- a/plugins/textual_inversion_loader.json
+++ b/plugins/textual_inversion_loader.json
@@ -1,0 +1,16 @@
+
+{
+  "documentation": {
+    "tokens": {
+      "token": "the trigger token (word or phrase). whenever this word or phrase appears in image captions, the embedding will be trained.",
+      "path": "(optional) /path/to/embedding.bin. If omitted, tries to load an embedding from the resume_ckpt diffusers folder, textual_inversions/<token>.bin where <token> is the token"
+    },
+    "example": "the example below tries to load textual_inversions/hat*.bin from inside the resume ckpt's textual_inversion folder and textual_inversions/dancing shoes.bin from inside the model folder, and cane from the path specified."
+  },
+  "tokens": [
+    { "token": "hat*" },
+    { "token": "dancing shoes" },
+    { "token": "cane", "path": "/workspace/embeddings/my_cane_embedding_ep30.bin"}
+  ]
+
+}

--- a/train.py
+++ b/train.py
@@ -1066,7 +1066,7 @@ def main(args):
                                                                         vae=vae,
                                                                         diffusers_scheduler_config=inference_scheduler.config
                                                                         ).to(device)
-                sample_generator.generate_samples(inference_pipe, global_step, extra_info=extra_info)
+                sample_generator.generate_samples(inference_pipe, global_step, extra_info=extra_info, plugin_runner=plugin_runner)
 
                 # Cleanup
                 del inference_pipe

--- a/train.py
+++ b/train.py
@@ -792,6 +792,7 @@ def main(args):
     plugin_runner.run_on_model_load(
         ed_state=EveryDreamTrainingState(unet=unet, text_encoder=text_encoder, tokenizer=tokenizer, vae=vae,
                                          optimizer=None, train_batch=None, scheduler=noise_scheduler, unet_ema=None, text_encoder_ema=None),
+        resume_ckpt=args.resume_ckpt,
         optimizer_config=optimizer_config,
         disable_unet_training=args.disable_unet_training,
         disable_textenc_training=args.disable_textenc_training

--- a/train.py
+++ b/train.py
@@ -168,7 +168,6 @@ def save_model(save_path, ed_state: EveryDreamTrainingState, global_step: int, s
             logging.info(f" * Saving yaml to {yaml_save_path}")
             shutil.copyfile(yaml_name, yaml_save_path)
 
-
     if global_step is None or global_step == 0:
         logging.warning("  No model to save, something likely blew up on startup, not saving")
         return
@@ -188,11 +187,6 @@ def save_model(save_path, ed_state: EveryDreamTrainingState, global_step: int, s
         diffusers_model_path = save_path + "_ema"
         logging.info(f" * Saving diffusers EMA model to {diffusers_model_path}")
         pipeline_ema.save_pretrained(diffusers_model_path)
-
-        plugin_runner.run_on_model_save(
-            ed_state=ed_state,
-            diffusers_save_path=diffusers_model_path
-        )
 
         if save_ckpt:
             sd_ckpt_path_ema = f"{os.path.basename(save_path)}_ema.safetensors"
@@ -222,6 +216,11 @@ def save_model(save_path, ed_state: EveryDreamTrainingState, global_step: int, s
     if save_optimizer_flag:
         logging.info(f" Saving optimizer state to {save_path}")
         ed_state.optimizer.save(save_path)
+
+    plugin_runner.run_on_model_save(
+        ed_state=ed_state,
+        diffusers_save_path=diffusers_model_path
+    )
 
 
 def setup_local_logger(args):

--- a/train.py
+++ b/train.py
@@ -792,7 +792,9 @@ def main(args):
     plugin_runner.run_on_model_load(
         ed_state=EveryDreamTrainingState(unet=unet, text_encoder=text_encoder, tokenizer=tokenizer, vae=vae,
                                          optimizer=None, train_batch=None, scheduler=noise_scheduler, unet_ema=None, text_encoder_ema=None),
-        optimizer_config=optimizer_config
+        optimizer_config=optimizer_config,
+        disable_unet_training=args.disable_unet_training,
+        disable_textenc_training=args.disable_textenc_training
     )
 
     data_loader = DataLoaderMultiAspect(
@@ -882,7 +884,7 @@ def main(args):
                 time.sleep(2) # give opportunity to ctrl-C again to cancel save
                 save_model(interrupted_checkpoint_path, global_step=global_step, ed_state=make_current_ed_state(),
                            save_ckpt_dir=args.save_ckpt_dir, yaml_name=yaml, save_full_precision=args.save_full_precision,
-                           save_optimizer_flag=args.save_optimizer, save_ckpt=not args.no_save_ckpt)
+                           save_optimizer_flag=args.save_optimizer, save_ckpt=not args.no_save_ckpt, plugin_runner=plugin_runner)
             exit(_SIGTERM_EXIT_CODE)
         else:
             # non-main threads (i.e. dataloader workers) should exit cleanly
@@ -1249,7 +1251,7 @@ def main(args):
                     save_model(save_path, global_step=global_step, ed_state=make_current_ed_state(),
                                save_ckpt_dir=args.save_ckpt_dir, yaml_name=None,
                                save_full_precision=args.save_full_precision,
-                               save_optimizer_flag=args.save_optimizer, save_ckpt=not args.no_save_ckpt)
+                               save_optimizer_flag=args.save_optimizer, save_ckpt=not args.no_save_ckpt, plugin_runner=plugin_runner)
 
                 plugin_runner.run_on_step_end(epoch=epoch,
                                       global_step=global_step,
@@ -1296,7 +1298,7 @@ def main(args):
         save_path = make_save_path(epoch, global_step, prepend=("" if args.no_prepend_last else "last-"))
         save_model(save_path, global_step=global_step, ed_state=make_current_ed_state(),
                    save_ckpt_dir=args.save_ckpt_dir, yaml_name=yaml, save_full_precision=args.save_full_precision,
-                   save_optimizer_flag=args.save_optimizer, save_ckpt=not args.no_save_ckpt)
+                   save_optimizer_flag=args.save_optimizer, save_ckpt=not args.no_save_ckpt, plugin_runner=plugin_runner)
 
         total_elapsed_time = time.time() - training_start_time
         logging.info(f"{Fore.CYAN}Training complete{Style.RESET_ALL}")
@@ -1308,7 +1310,7 @@ def main(args):
         save_path = make_save_path(epoch, global_step, prepend="errored-")
         save_model(save_path, global_step=global_step, ed_state=make_current_ed_state(),
                    save_ckpt_dir=args.save_ckpt_dir, yaml_name=yaml, save_full_precision=args.save_full_precision,
-                   save_optimizer_flag=args.save_optimizer, save_ckpt=not args.no_save_ckpt)
+                   save_optimizer_flag=args.save_optimizer, save_ckpt=not args.no_save_ckpt, plugin_runner=plugin_runner)
         logging.info(f"{Fore.LIGHTYELLOW_EX}Model saved, re-raising exception and exiting.  Exception was:{Style.RESET_ALL}{Fore.LIGHTRED_EX} {ex} {Style.RESET_ALL}")
         raise ex
 

--- a/train.py
+++ b/train.py
@@ -119,12 +119,12 @@ def convert_to_hf(ckpt_path):
 
 class EveryDreamTrainingState:
     def __init__(self,
-                 optimizer: EveryDreamOptimizer,
-                 train_batch: EveryDreamBatch,
+                 optimizer: Optional[EveryDreamOptimizer],
+                 train_batch: Optional[EveryDreamBatch],
                  unet: UNet2DConditionModel,
                  text_encoder: CLIPTextModel,
                  tokenizer: CLIPTokenizer,
-                 scheduler,
+                 scheduler: Optional,
                  vae: AutoencoderKL,
                  unet_ema: Optional[UNet2DConditionModel],
                  text_encoder_ema: Optional[CLIPTextModel]
@@ -791,7 +791,8 @@ def main(args):
     from plugins.plugins import PluginRunner
     plugin_runner = PluginRunner(plugins=plugins)
     plugin_runner.run_on_model_load(
-        ed_state=EveryDreamTrainingState(unet=unet, text_encoder=text_encoder, tokenizer=tokenizer, vae=vae),
+        ed_state=EveryDreamTrainingState(unet=unet, text_encoder=text_encoder, tokenizer=tokenizer, vae=vae,
+                                         optimizer=None, train_batch=None, scheduler=noise_scheduler, unet_ema=None, text_encoder_ema=None),
         optimizer_config=optimizer_config
     )
 

--- a/train.py
+++ b/train.py
@@ -903,7 +903,7 @@ def main(args):
 
     train_dataloader = build_torch_dataloader(train_batch, batch_size=args.batch_size)
 
-    unet.train() if not args.disable_unet_training else unet.eval()
+    unet.train() if (args.gradient_checkpointing or not args.disable_unet_training) else unet.eval()
     text_encoder.train() if not args.disable_textenc_training else text_encoder.eval()
 
     logging.info(f" unet device: {unet.device}, precision: {unet.dtype}, training: {unet.training}")
@@ -1181,7 +1181,7 @@ def main(args):
                     runt_loss_scale = (batch["runt_size"] / args.batch_size)**1.5 # further discount runts by **1.5
                     loss = loss * runt_loss_scale
 
-                ed_optimizer.step(loss, step, global_step)
+                ed_optimizer.step(loss, step, global_step, plugin_runner=plugin_runner, ed_state=make_current_ed_state())
 
                 if args.ema_decay_rate != None:
                     if ((global_step + 1) % args.ema_update_interval) == 0:


### PR DESCRIPTION
With this plugin you can target specific token embeddings in the text encoder, and/or add new ones. The embeddings get written into the model's text encoder and saved out - not the most efficient way to share them, but useful if you want to laser-focus training of specific or custom tokens in your model.

Documentation (such as it is) is in plugins/textual_inversion.py. TL;DR is - first edit plugins/textual_inversion.json to set up your tokens and initialization states. enable text encoder training and disable unet training. then edit optimizer.json to freeze all TE layers and TE final layer norm. the plugin checks for sane config when it's used.

you'll want to use a very high LR for the TE. my last test worked best at 2e-2. 