### PR TITLE
Fixs error when translated caption contains an unusual byte

### DIFF
--- a/caption_cog.py
+++ b/caption_cog.py
@@ -139,7 +139,7 @@ def main(args):
             caption = tokenizer.decode(outputs_without_prompt[0], skip_special_tokens=True)
             caption += args.append
 
-            with open(candidate_caption_path, "w") as f:
+            with open(candidate_caption_path, "w", encoding="utf-8") as f:
                 f.write(caption)
             vram_gb = get_gpu_memory_map()
             elapsed_time = time.time() - start_time

--- a/caption_cog.py
+++ b/caption_cog.py
@@ -84,7 +84,7 @@ def main(args):
         del gen_kwargs["max_length"]
 
     if not do_sample:
-        print(f"** Using greedy sampling")
+        print(f"** Using greedy search instead sampling. Generated captions will be deterministic; meaning it will be the same even if you run this program multiple times.")
         del gen_kwargs["top_k"]
         del gen_kwargs["top_p"]
         del gen_kwargs["temperature"]


### PR DESCRIPTION
fixs this
File "D:\EveryDream2trainer\caption_cog.py", line 143, in main
    f.write(caption)
UnicodeEncodeError: 'cp949' codec can't encode character '\xe9' in position 333: illegal multibyte sequence